### PR TITLE
ci: add Dependabot github-actions config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    # Two groups by change risk so a broken major bump doesn't park the
+    # weekly patch/minor rollup (including security patches for sibling
+    # actions). Dependabot still opens at most two PRs per week.
+    groups:
+      actions-patch-minor:
+        update-types: ["patch", "minor"]
+      actions-major:
+        update-types: ["major"]
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` so the workflow's pinned third-party actions (`actions/checkout`, `cycjimmy/semantic-release-action`, `voidzero-dev/setup-vp`) get a maintained update path.
- Mirrors the canonical shape used in `putio-web` and `putio-ios`: weekly Monday cadence, grouped patch/minor + major streams, `ci:` commit prefix.

## Test plan
- [x] yaml parses (Dependabot will reject invalid config on push)
- [ ] first scheduled run on Monday opens at most two PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)