### PR TITLE
ci: harden TypeScript SDK release environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@45e5c098f1095cc6b65fd92534603e7be70386c1 # v1
         with:
           node-version-file: ".node-version"
           cache: true
@@ -47,12 +47,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@45e5c098f1095cc6b65fd92534603e7be70386c1 # v1
         with:
           node-version-file: ".node-version"
           cache: true
@@ -73,9 +73,7 @@ jobs:
     timeout-minutes: 20
     environment: release
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
 
     steps:
       - name: Create release bot token
@@ -93,16 +91,14 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.release-bot.outputs.token }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@45e5c098f1095cc6b65fd92534603e7be70386c1 # v1
         with:
           node-version-file: ".node-version"
-
-      - name: Enable Corepack
-        run: corepack enable
+          cache: true
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: vp install
 
       - name: Release package
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,20 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Create release bot token
+        id: release-bot
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.PUTIO_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.PUTIO_RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          token: ${{ steps.release-bot.outputs.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -105,9 +115,9 @@ jobs:
             @semantic-release/git
             conventional-changelog-conventionalcommits
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GIT_AUTHOR_NAME: devsputio
-          GIT_AUTHOR_EMAIL: devs@put.io
-          GIT_COMMITTER_NAME: devsputio
-          GIT_COMMITTER_EMAIL: devs@put.io
+          GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   verify:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     name: Verify SDK
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -40,7 +40,7 @@ jobs:
   verify-consumer-surface:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     name: Verify consumer surface
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -69,7 +69,7 @@ jobs:
     needs:
       - verify
       - verify-consumer-surface
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     environment: release
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
       - verify-consumer-surface
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 20
+    environment: release
     permissions:
       contents: write
       issues: write
@@ -78,21 +79,23 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@v1
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".node-version"
-          cache: true
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: vp install
+        run: pnpm install --frozen-lockfile
 
       - name: Release package
-        uses: cycjimmy/semantic-release-action@v6
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
           extra_plugins: |
             @semantic-release/commit-analyzer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - [Architecture](./docs/ARCHITECTURE.md)
 - [Testing](./docs/TESTING.md)
 - [Readiness](./docs/READINESS.md)
-- [Release](./docs/RELEASE.md)
+- [Distribution](./docs/DISTRIBUTION.md)
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Useful references:
 
 - [Architecture](./docs/ARCHITECTURE.md)
 - [Testing](./docs/TESTING.md)
-- [Release](./docs/RELEASE.md)
+- [Distribution](./docs/DISTRIBUTION.md)
 - [Readiness](./docs/READINESS.md)
 
 ## Pull Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Install dependencies with Vite+:
 vp install
 ```
 
-Then install the stock VitePlus hook wiring for this clone:
+Then install the stock Vite+ hook wiring for this clone:
 
 ```bash
 vp config

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ export const useFiles = (parentId: number) =>
 - [Architecture](./docs/ARCHITECTURE.md) for package shape and boundaries
 - [Testing](./docs/TESTING.md) for local and live verification
 - [Readiness](./docs/READINESS.md) for domain readiness
-- [Release](./docs/RELEASE.md) for release automation
+- [Distribution](./docs/DISTRIBUTION.md) for release automation
 - [Security](./SECURITY.md) for private-first vulnerability disclosure
 
 ## Contributing

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,10 +1,10 @@
-# Release
+# Distribution
 
 ## Delivery Model
 
 Every merge to `main` should already be releasable.
 
-GitHub Actions owns releases for this repo and the workflow runs on Blacksmith-hosted Ubuntu runners.
+GitHub Actions owns releases for this repo and the workflow runs on GitHub-hosted Ubuntu runners.
 
 The pipeline does three things on `main`:
 
@@ -26,7 +26,12 @@ The release lane:
 
 The release job declares the protected GitHub Environment named `release`.
 
-Configure that Environment with required reviewers and prevent self-review before enabling npm publish automation.
+Environment entries:
+
+- secrets: `NPM_TOKEN`, `PUTIO_RELEASE_BOT_PRIVATE_KEY`
+- variables: `PUTIO_RELEASE_BOT_APP_ID`
+- approval: none; releases are continuous after the `main` gate passes
+- refs: release branch/tag policy constrains what can publish
 
 Release GitHub writes use `putio-release-bot` through `PUTIO_RELEASE_BOT_APP_ID` and `PUTIO_RELEASE_BOT_PRIVATE_KEY`. `NPM_TOKEN` must live in the `release` Environment, not as a plain repository secret, so pull request jobs never receive publish credentials.
 
@@ -34,7 +39,7 @@ Public-repo branch policy may still allow trusted put.io team members to push di
 
 ## Local Checks
 
-Before changing release wiring, validate the repo-local guardrails the workflow depends on:
+Before changing distribution wiring, validate the repo-local guardrails the workflow depends on:
 
 ```bash
 vp install

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,9 +28,9 @@ The release job declares the protected GitHub Environment named `release`.
 
 Configure that Environment with required reviewers and prevent self-review before enabling npm publish automation.
 
-`GITHUB_TOKEN` is provided by GitHub Actions automatically. `NPM_TOKEN` must live in the `release` Environment, not as a plain repository secret, so pull request jobs never receive publish credentials.
+Release GitHub writes use `putio-release-bot` through `PUTIO_RELEASE_BOT_APP_ID` and `PUTIO_RELEASE_BOT_PRIVATE_KEY`. `NPM_TOKEN` must live in the `release` Environment, not as a plain repository secret, so pull request jobs never receive publish credentials.
 
-Public-repo branch policy may still allow trusted put.io team members to push directly to `main`, but it should block outsiders, force-pushes, and branch deletes where GitHub plan support allows. Release tag policy should restrict `v*` tag creation or updates to the release automation token and release admins.
+Public-repo branch policy may still allow trusted put.io team members to push directly to `main`, but it should block outsiders, force-pushes, and branch deletes where GitHub plan support allows. Release tag policy restricts `v*` tag creation, update, and deletion to `putio-release-bot` and org admins.
 
 ## Local Checks
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -22,13 +22,15 @@ The release lane:
 - creates the GitHub release
 - commits the released `package.json` version back to `main`
 
-## Required Secrets
+## Release Environment
 
-- `NPM_TOKEN`
-- `GITHUB_TOKEN`
+The release job declares the protected GitHub Environment named `release`.
 
-`GITHUB_TOKEN` is provided by GitHub Actions automatically.
-`NPM_TOKEN` must be configured in the repository or organization secrets before the release job can publish.
+Configure that Environment with required reviewers and prevent self-review before enabling npm publish automation.
+
+`GITHUB_TOKEN` is provided by GitHub Actions automatically. `NPM_TOKEN` must live in the `release` Environment, not as a plain repository secret, so pull request jobs never receive publish credentials.
+
+Public-repo branch policy may still allow trusted put.io team members to push directly to `main`, but it should block outsiders, force-pushes, and branch deletes where GitHub plan support allows. Release tag policy should restrict `v*` tag creation or updates to the release automation token and release admins.
 
 ## Local Checks
 


### PR DESCRIPTION
## Summary

## Changed
- Move npm release publishing behind the protected release environment
- Use putio-release-bot for release writes and version bump commits
- Use GitHub-hosted runners for CI

## Risks
- Release jobs depend on PUTIO_RELEASE_BOT_APP_ID and PUTIO_RELEASE_BOT_PRIVATE_KEY being present in the release Environment

## Verification
- actionlint passes locally for the touched workflow
- CI will verify the branch

## Complexity
- Neutral: release identity wiring is explicit but follows the shared put.io pattern