### PR TITLE
ci(release): use npm trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   verify:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
@@ -20,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -50,7 +52,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -83,11 +85,12 @@ jobs:
       deployment: false
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Create release bot token
         id: release-bot
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           client-id: ${{ vars.PUTIO_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.PUTIO_RELEASE_BOT_PRIVATE_KEY }}
@@ -95,10 +98,10 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ steps.release-bot.outputs.token }}
+          persist-credentials: false
 
       - name: Set up Vite+
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
@@ -108,6 +111,11 @@ jobs:
 
       - name: Install dependencies
         run: vp install
+
+      - name: Configure release bot remote
+        run: git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        env:
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
 
       - name: Release package
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
@@ -121,7 +129,6 @@ jobs:
             conventional-changelog-conventionalcommits@9.3.1
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
           GIT_AUTHOR_EMAIL: ${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -10,7 +10,8 @@ The pipeline does three things on `main`:
 
 1. `vp install`
 2. `vp run verify`
-3. run `semantic-release` through the release action
+3. `vp run test:live:consumer`
+4. run `semantic-release` through the release action
 
 The workflow uses `.releaserc.json` as the release source of truth. The release action is SHA-pinned and every `extra_plugins` entry is version-pinned, so the secret-bearing release job does not fetch unversioned semantic-release plugins.
 
@@ -28,15 +29,21 @@ The release job declares the protected GitHub Environment named `release`.
 
 Environment entries:
 
-- secrets: `NPM_TOKEN`, `PUTIO_RELEASE_BOT_PRIVATE_KEY`
+- secrets: `PUTIO_RELEASE_BOT_PRIVATE_KEY`
 - variables: `PUTIO_RELEASE_BOT_CLIENT_ID`
 - approval: none; releases are continuous after the `main` gate passes
 - refs: release branch/tag policy constrains what can publish
 - deployment records: disabled with `deployment: false` because this is package publishing, not an app deploy
 
-Release GitHub writes use `putio-release-bot` through `PUTIO_RELEASE_BOT_CLIENT_ID` and `PUTIO_RELEASE_BOT_PRIVATE_KEY`. Keep `NPM_TOKEN` in the `release` Environment so pull request jobs stay publish-secret-free.
+The npm package uses Trusted Publishing from GitHub Actions. On npm, configure owner `putdotio`, repository `putio-sdk-typescript`, workflow `ci.yml`, and Environment named `release` for the package.
+
+The workflow grants `id-token: write` so npm mints short-lived publish credentials and provenance for the release job. The package repository metadata points at `putdotio/putio-sdk-typescript` so npm can match the OIDC publisher identity.
+
+Release GitHub writes use `putio-release-bot` through `PUTIO_RELEASE_BOT_CLIENT_ID` and `PUTIO_RELEASE_BOT_PRIVATE_KEY`.
 
 The workflow keeps dependency caches only on secretless verify jobs. The secret-bearing release job runs a fresh `vp install` with package-manager caching disabled before publishing to npm.
+
+The release-bot remote is configured only after dependencies are installed.
 
 Public-repo branch policy may still allow trusted put.io team members to push directly to `main`, but it should block outsiders, force-pushes, and branch deletes where GitHub plan support allows. Release tag policy restricts `v*` tag creation, update, and deletion to `putio-release-bot` and org admins.
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -6,7 +6,7 @@ Every merge to `main` should already be releasable.
 
 GitHub Actions owns releases for this repo and the workflow runs on GitHub-hosted Ubuntu runners.
 
-The pipeline does three things on `main`:
+The pipeline runs these release steps on `main`:
 
 1. `vp install`
 2. `vp run verify`
@@ -37,7 +37,7 @@ Environment entries:
 
 The npm package uses Trusted Publishing from GitHub Actions. On npm, configure owner `putdotio`, repository `putio-sdk-typescript`, workflow `ci.yml`, and Environment named `release` for the package.
 
-The workflow grants `id-token: write` so npm mints short-lived publish credentials and provenance for the release job. The package repository metadata points at `putdotio/putio-sdk-typescript` so npm can match the OIDC publisher identity.
+During the `@semantic-release/npm` publish step, npm detects the GitHub OIDC identity, mints short-lived publish credentials, and publishes provenance for the release job. The package repository metadata points at `putdotio/putio-sdk-typescript` so npm can match the OIDC publisher identity.
 
 Release GitHub writes use `putio-release-bot` through `PUTIO_RELEASE_BOT_CLIENT_ID` and `PUTIO_RELEASE_BOT_PRIVATE_KEY`.
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   ],
   "license": "MIT",
   "author": "put.io <devs@put.io>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/putdotio/putio-sdk-typescript.git"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

Move the TypeScript SDK release workflow to npm Trusted Publishing from GitHub Actions.

## Changed

- Grants the release job `id-token: write` for npm OIDC authentication
- Keeps release checkout credentials unpersisted through install and configures the release-bot remote only at the release boundary
- Removes the workflow dependency on `NPM_TOKEN`
- Adds package repository metadata for `putdotio/putio-sdk-typescript` so npm can match the OIDC publisher identity
- Updates distribution docs with the current release credential model

## Risks

The npm package needs a trusted publisher configured for owner `putdotio`, repository `putio-sdk-typescript`, workflow `ci.yml`, and Environment `release` before the first tokenless release run.

## Verification

- `git diff --check`
- `actionlint .github/workflows/ci.yml`
- `pnpm install`
- `pnpm run verify`
- `pnpm run test:live:consumer`

## Complexity

Neutral. The release path keeps the existing semantic-release flow while swapping npm publish authentication to OIDC.