### PR TITLE
chore(sdk): keep live env example public-safe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,17 @@
 # Live SDK verification env file.
-# Run `pnpm secrets:setup` to materialize .env.local from these references.
+# Copy this to `.env` or `.env.local` and fill only the values needed by the live targets you run.
 
 # Bootstrap creds — used by `bootstrap:tokens` and credential live tests to mint fresh tokens.
-PUTIO_TEST_USERNAME="op://frontend-ci/putio-test-account/username"
-PUTIO_TEST_PASSWORD="op://frontend-ci/putio-test-account/password"
-PUTIO_TEST_TOTP_REFERENCE="op://frontend-ci/putio-test-account/one-time password"
-PUTIO_CLIENT_ID_FIRST_PARTY="op://frontend-ci/putio-oauth-first-party/CLIENT_ID"
-PUTIO_CLIENT_SECRET_FIRST_PARTY="op://frontend-ci/putio-oauth-first-party/CLIENT_SECRET"
+PUTIO_TEST_USERNAME=""
+PUTIO_TEST_PASSWORD=""
+PUTIO_TEST_TOTP_REFERENCE=""
+PUTIO_CLIENT_ID_FIRST_PARTY=""
+PUTIO_CLIENT_SECRET_FIRST_PARTY=""
 
 # Pre-existing tokens — used by the broader live test suite (zips, files, transfers, etc.)
-PUTIO_TOKEN_FIRST_PARTY="op://frontend-ci/putio-sdk-testing/first_party/access_token"
-PUTIO_TOKEN_THIRD_PARTY="op://frontend-ci/putio-sdk-testing/third_party/access_token"
-PUTIO_CLIENT_ID="op://frontend-ci/putio-sdk-testing/third_party/app_id"
+PUTIO_TOKEN_FIRST_PARTY=""
+PUTIO_TOKEN_THIRD_PARTY=""
+PUTIO_CLIENT_ID=""
 
 # Role-specific live fixtures.
 # Set these in .env.local or the shell when running the matching domain targets.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,11 +57,11 @@ The package-surface checks do not require live credentials. Use live tests when 
 Bootstrap runtime tokens with 1Password:
 
 ```bash
-pnpm secrets:setup        # materializes .env.local from .env.example via op inject
+pnpm secrets:setup        # materializes .env.local from a private .env.1password file
 pnpm bootstrap:tokens     # mints fresh first/third-party tokens against the live API
 ```
 
-`secrets:setup` requires an unlocked 1Password CLI session locally, or `OP_SERVICE_ACCOUNT_TOKEN` exported on shared devboxes / CI. Run `pnpm secrets:clean` before tearing down the worktree.
+`secrets:setup` requires a gitignored `.env.1password` file with private `op://` references, plus an unlocked 1Password CLI session locally or `OP_SERVICE_ACCOUNT_TOKEN` exported on shared devboxes / CI. Run `pnpm secrets:clean` before tearing down the worktree.
 
 For single-target commands, safety rules, and fixture expectations, see [Testing](./docs/TESTING.md).
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -155,7 +155,7 @@ Single target:
 vp pack && vp test run --config vitest.live.config.ts test/live/auth.test.ts
 ```
 
-Run `pnpm secrets:setup` once per worktree to materialize `.env.local` from `.env.example` via `op inject`. The materialised file is `0600` and gitignored. Live commands auto-load `.env.local` first and then `.env`; already-exported environment variables keep highest priority.
+Run `pnpm secrets:setup` once per worktree to materialize `.env.local` from a gitignored `.env.1password` file via `op inject`. The materialized file is `0600` and gitignored. Live commands auto-load `.env.local` first and then `.env`; already-exported environment variables keep highest priority.
 
 ```bash
 pnpm secrets:setup        # one-time per worktree
@@ -165,7 +165,7 @@ pnpm test:live            # runs the broader live suite against pre-existing tok
 pnpm secrets:clean        # before `git worktree remove`
 ```
 
-`secrets:setup` requires an unlocked 1Password CLI session locally, or `OP_SERVICE_ACCOUNT_TOKEN` exported on shared devboxes / CI. The `.env.example` references are committer-only; external contributors can run unit tests without them.
+`secrets:setup` requires private maintainer `op://` references in `.env.1password`, plus an unlocked 1Password CLI session locally or `OP_SERVICE_ACCOUNT_TOKEN` exported on shared devboxes / CI. External contributors can copy `.env.example` manually for their own live credentials, and unit tests do not require live credentials.
 
 `bootstrap:live-fixtures` validates and seeds the live fixtures that are safe to
 prepare through the public SDK. It establishes the secondary friendship/shared

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:unused:prod": "vp pack && knip --production",
     "prepare": "./scripts/prepare-effect.sh",
     "prepack": "vp pack",
-    "secrets:setup": "OP_ACCOUNT=putdotio.1password.com op whoami >/dev/null && OP_ACCOUNT=putdotio.1password.com op inject -f -i .env.example -o .env.local",
+    "secrets:setup": "bash ./scripts/secrets-setup.sh",
     "secrets:clean": "rm -f .env.local .env.local.* .env.local.swp",
     "test": "vp test --passWithNoTests",
     "test:live": "vp pack && vp test run --config vitest.live.config.ts",

--- a/scripts/secrets-setup.sh
+++ b/scripts/secrets-setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+input=".env.1password"
+output=".env.local"
+op_account="${OP_ACCOUNT:-putdotio.1password.com}"
+
+if [ ! -f "$input" ]; then
+  echo "Missing $input. Create it from private maintainer docs before running secrets:setup." >&2
+  exit 1
+fi
+
+OP_ACCOUNT="$op_account" op whoami >/dev/null
+OP_ACCOUNT="$op_account" op inject -f -i "$input" -o "$output"
+chmod 600 "$output"


### PR DESCRIPTION
## Summary

Keep the public TypeScript SDK env example free of private 1Password paths while preserving maintainer secret setup.

## Changed

- Replace private `op://` references in `.env.example` with empty public-safe placeholders
- Move maintainer `op inject` flow to `scripts/secrets-setup.sh` using a gitignored `.env.1password`
- Update live-test docs for the new public/private env split

## Risks

Low. Maintainers now need the private `.env.1password` input before running `pnpm secrets:setup`.

## Verification

- `bash -n scripts/secrets-setup.sh`
- `pnpm check .`
- `pnpm test -- test/live/support/secrets.test.ts`
- `codex-review --mode auto` clean
- `review` verdict: ship it

## Complexity

Neutral. Adds a tiny script to keep private refs out of public examples.
