### PR TITLE
chore(test): exclude local effect checkout

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ const coverageConfig = {
     "src/**/*.spec.*",
     "src/**/*.d.ts",
     "src/test-support/**",
+    ".repos/**",
     "dist/**",
     "coverage/**",
   ],
@@ -35,7 +36,7 @@ export default defineConfig({
   },
   test: {
     coverage: coverageConfig,
-    exclude: ["test/live/**"],
+    exclude: [".repos/**", "test/live/**"],
     include: ["src/**/*.spec.ts", "src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Exclude the local Effect source checkout from Vite+ test and coverage discovery.

## Changed

- Add `.repos/**` to coverage exclusions.
- Add `.repos/**` to test exclusions.

## Risks

Low; this only prevents locally cloned Effect guidance/source from being discovered by SDK test and coverage collection.

## Verification

- `pnpm exec vp check .`
- `pnpm exec vp test --passWithNoTests`
- `codex-review --mode auto`: clean.

## Complexity

Neutral.
