### PR TITLE
feat(auth): pass callback url through login

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const sdk = createPutioSdkPromiseClient();
 
 const validation = await sdk.auth.validateToken(tokenToCheck);
 const login = await sdk.auth.login({
+  callbackUrl,
   clientId,
   clientSecret,
   password,

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -42,6 +42,7 @@ import {
   validateToken,
   verifyTOTP,
   type GenerateTOTPResponse,
+  type LoginInput,
   type LoginResponse,
   type RegisterInput,
   type TwoFactorRecoveryCodes,
@@ -664,14 +665,7 @@ export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape =
       getVoucher: (code: string) => provideSdk(config, getVoucher(code)),
       grants: (): Promise<ReadonlyArray<OAuthApp>> => provideSdk(config, grants()),
       linkDevice: (code: string) => provideSdk(config, linkDevice(code)),
-      login: (input: {
-        readonly clientId: string | number;
-        readonly clientSecret: string;
-        readonly password: string;
-        readonly username: string;
-        readonly clientName?: string;
-        readonly fingerprint?: string;
-      }): Promise<LoginResponse> => provideSdk(config, login(input)),
+      login: (input: LoginInput): Promise<LoginResponse> => provideSdk(config, login(input)),
       logout: () => provideSdk(config, logout()),
       register: (input: RegisterInput) => provideSdk(config, register(input)),
       resetPassword: (key: string, password: string) =>

--- a/src/domains/auth.spec.ts
+++ b/src/domains/auth.spec.ts
@@ -67,6 +67,7 @@ describe("auth domain", () => {
 
     const loginResult = await runSdkEffect(
       login({
+        callbackUrl: "https://example.com/callback",
         clientId: 42,
         clientName: "Codex",
         clientSecret: "secret",
@@ -76,7 +77,7 @@ describe("auth domain", () => {
       }),
       (request) => {
         expect(request.url).toBe(
-          "https://api.put.io/v2/oauth2/authorizations/clients/42/fingerprint-1?client_name=Codex&client_secret=secret",
+          "https://api.put.io/v2/oauth2/authorizations/clients/42/fingerprint-1?callback_url=https%3A%2F%2Fexample.com%2Fcallback&client_name=Codex&client_secret=secret",
         );
         expect(getAuthorizationHeader(request)).toBe("Basic c2RrOnBhc3M=");
 

--- a/src/domains/auth.ts
+++ b/src/domains/auth.ts
@@ -301,6 +301,15 @@ export type RecoveryCodesError = PutioOperationFailure<typeof RecoveryCodesError
 export type RegenerateRecoveryCodesError = PutioOperationFailure<
   typeof RegenerateRecoveryCodesErrorSpec
 >;
+export type LoginInput = {
+  readonly clientId: string | number;
+  readonly clientSecret: string;
+  readonly password: string;
+  readonly username: string;
+  readonly callbackUrl?: string;
+  readonly clientName?: string;
+  readonly fingerprint?: string;
+};
 export const buildAuthLoginUrl = (options: {
   readonly clientId: string | number;
   readonly redirectUri: string;
@@ -317,14 +326,9 @@ export const buildAuthLoginUrl = (options: {
     response_type: options.responseType ?? "token",
     state: options.state,
   });
-export const login = (input: {
-  readonly clientId: string | number;
-  readonly clientSecret: string;
-  readonly password: string;
-  readonly username: string;
-  readonly clientName?: string;
-  readonly fingerprint?: string;
-}): Effect.Effect<LoginResponse, LoginError, PutioSdkContext> =>
+export const login = (
+  input: LoginInput,
+): Effect.Effect<LoginResponse, LoginError, PutioSdkContext> =>
   requestJson(LoginResponseSchema, {
     auth: {
       type: "basic",
@@ -336,6 +340,7 @@ export const login = (input: {
       ? `/v2/oauth2/authorizations/clients/${encodePathSegment(input.clientId)}/${encodePathSegment(input.fingerprint)}`
       : `/v2/oauth2/authorizations/clients/${encodePathSegment(input.clientId)}`,
     query: {
+      callback_url: input.callbackUrl,
       client_name: input.clientName,
       client_secret: input.clientSecret,
     },


### PR DESCRIPTION
## Summary

Adds a `callbackUrl` option to `auth.login` and serializes it as `callback_url` for the credential login endpoint.

## Changed

- Adds a public `LoginInput` type for the auth login surface
- Reuses that type in the Promise client
- Sends `callback_url` through the existing query builder
- Updates request-shape coverage and README usage

## Risks

Low. Existing login calls keep the same required fields and the new field is optional. Current backend behavior accepts the query parameter but does not enforce callback behavior yet, so server-side callback validation remains a backend follow-up.

## Verification

- `vp run verify`
- `git diff --check`
- focused live probe confirmed login requests with `callback_url` are accepted and resulting tokens validate
- `autoreview --mode branch --base origin/main` clean

## Complexity

Neutral. This narrows duplicate inline typing by sharing the public login input type.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional `callbackUrl` to `auth.login`, sent as `callback_url` in the login request. Introduces a public `LoginInput` type used by the Promise client, with tests and README updated.

<sup>Written for commit e33b8c32639eda78497411acd79b4f4d77fcceed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/putdotio/putio-sdk-typescript/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

