### PR TITLE
fix(payment)!: update payment provider contracts

### DIFF
--- a/src/core/client.promise.spec.ts
+++ b/src/core/client.promise.spec.ts
@@ -309,10 +309,13 @@ vi.mock("../domains/payment.js", async () => {
     classifyPaymentChangePlanResponse: vi.fn((input) => ({ classified: input })),
     confirmFastspringOrder: vi.fn((reference) => Effect.succeed(reference === "ok")),
     createCoinbaseCharge: vi.fn((planPath) => Effect.succeed(`coinbase:${planPath}`)),
-    createNanoPaymentRequest: vi.fn((planCode) => Effect.succeed(`nano:${planCode}`)),
     createOpenNodeCharge: vi.fn((planPath) => Effect.succeed(`opennode:${planPath}`)),
+    createPaddleBillingUpdatePaymentMethodTransaction: vi.fn((id) =>
+      Effect.succeed(`paddle-billing-update:${id}`),
+    ),
     createPaddleWaitingPayment: vi.fn((input) => Effect.succeed({ waiting: input })),
     getPaymentInfo: vi.fn(() => Effect.succeed({ active: true })),
+    getPaddleBillingInvoiceUrl: vi.fn((id) => Effect.succeed(`paddle-billing-invoice:${id}`)),
     getPaymentVoucherInfo: vi.fn((code) => Effect.succeed({ code, valid: true })),
     listPaymentHistory: vi.fn((query) => Effect.succeed([{ id: 1, query }])),
     listPaymentInvites: vi.fn(() => Effect.succeed([{ code: "invite" }])),
@@ -711,8 +714,13 @@ describe("sdk promise client adapters", () => {
       waiting: { plan: "pro" },
     });
     expect(await client.payment.methods.createCoinbaseCharge("pro")).toBe("coinbase:pro");
-    expect(await client.payment.methods.createNanoPaymentRequest("nano")).toBe("nano:nano");
     expect(await client.payment.methods.createOpenNodeCharge("pro")).toBe("opennode:pro");
+    expect(
+      await client.payment.methods.createPaddleBillingUpdatePaymentMethodTransaction(456),
+    ).toBe("paddle-billing-update:456");
+    expect(await client.payment.methods.getPaddleBillingInvoiceUrl(123)).toBe(
+      "paddle-billing-invoice:123",
+    );
     expect(await client.payment.report([1, 2])).toEqual({ reported: [1, 2] });
     expect(await client.payment.stopSubscription()).toEqual({ stopped: true });
     expect(await client.payment.voucher.getInfo("voucher")).toEqual({

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -178,10 +178,11 @@ import {
   classifyPaymentChangePlanResponse,
   confirmFastspringOrder,
   createCoinbaseCharge,
-  createNanoPaymentRequest,
   createOpenNodeCharge,
+  createPaddleBillingUpdatePaymentMethodTransaction,
   createPaddleWaitingPayment,
   getPaymentInfo,
+  getPaddleBillingInvoiceUrl,
   getPaymentVoucherInfo,
   listPaymentHistory,
   listPaymentInvites,
@@ -488,8 +489,9 @@ export const createPutioSdkEffectClient = () => ({
     methods: {
       addPaddleWaitingPayment: createPaddleWaitingPayment,
       createCoinbaseCharge,
-      createNanoPaymentRequest,
       createOpenNodeCharge,
+      createPaddleBillingUpdatePaymentMethodTransaction,
+      getPaddleBillingInvoiceUrl,
     },
     report: reportPayments,
     stopSubscription: stopPaymentSubscription,
@@ -943,10 +945,14 @@ export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape =
           provideSdk(config, createPaddleWaitingPayment(input)),
         createCoinbaseCharge: (planPath: string): Promise<string> =>
           provideSdk(config, createCoinbaseCharge(planPath)),
-        createNanoPaymentRequest: (planCode: string): Promise<string> =>
-          provideSdk(config, createNanoPaymentRequest(planCode)),
         createOpenNodeCharge: (planPath: string): Promise<string> =>
           provideSdk(config, createOpenNodeCharge(planPath)),
+        createPaddleBillingUpdatePaymentMethodTransaction: (
+          userSubscriptionId: number,
+        ): Promise<string> =>
+          provideSdk(config, createPaddleBillingUpdatePaymentMethodTransaction(userSubscriptionId)),
+        getPaddleBillingInvoiceUrl: (paymentId: number): Promise<string> =>
+          provideSdk(config, getPaddleBillingInvoiceUrl(paymentId)),
       },
       report: (paymentIds: ReadonlyArray<number>) => provideSdk(config, reportPayments(paymentIds)),
       stopSubscription: () => provideSdk(config, stopPaymentSubscription()),

--- a/src/domains/payment.spec.ts
+++ b/src/domains/payment.spec.ts
@@ -211,6 +211,9 @@ describe("payment domain", () => {
               currency: "USD",
               next_billing_date: "2026-04-17",
             },
+            "Paddle Billing": {
+              next_billing_date: "2026-04-17",
+            },
             amount: "7.99",
             charge_amount: true,
             credit: null,
@@ -265,6 +268,11 @@ describe("payment domain", () => {
               provider: "Fastspring",
               type: "credit-card",
               url: "https://checkout.put.io",
+            },
+            {
+              price_id: "pri_123",
+              provider: "Paddle Billing",
+              type: "credit-card",
             },
           ],
         });
@@ -349,6 +357,32 @@ describe("payment domain", () => {
 
     expect(
       await runSdkEffect(
+        payment.getPaddleBillingInvoiceUrl(123),
+        (request) => {
+          expect(request.url).toBe(
+            "https://api.put.io/v2/payment/methods/paddle_billing/invoice/123",
+          );
+          return jsonResponse({ url: "https://paddle.test/invoice.pdf" });
+        },
+        { accessToken: "token-123" },
+      ),
+    ).toBe("https://paddle.test/invoice.pdf");
+
+    expect(
+      await runSdkEffect(
+        payment.createPaddleBillingUpdatePaymentMethodTransaction(456),
+        (request) => {
+          expect(request.url).toBe(
+            "https://api.put.io/v2/payment/methods/paddle_billing/update_payment_method/456",
+          );
+          return jsonResponse({ transaction_id: "txn_123" });
+        },
+        { accessToken: "token-123" },
+      ),
+    ).toBe("txn_123");
+
+    expect(
+      await runSdkEffect(
         payment.createCoinbaseCharge("plan/path"),
         (request) => {
           expect(getFormBody(request).get("plan_fs_path")).toBe("plan/path");
@@ -371,17 +405,6 @@ describe("payment domain", () => {
         { accessToken: "token-123" },
       ),
     ).toBe("https://checkout.opennode.com");
-
-    expect(
-      await runSdkEffect(
-        payment.createNanoPaymentRequest("nano-plan"),
-        (request) => {
-          expect(getFormBody(request).get("plan_code")).toBe("nano-plan");
-          return jsonResponse({ nano: { token: "nano-token" }, status: "OK" });
-        },
-        { accessToken: "token-123" },
-      ),
-    ).toBe("nano-token");
   });
 
   it("maps payment operation failures", async () => {
@@ -408,6 +431,82 @@ describe("payment domain", () => {
       domain: "payment",
       operation: "submitChangePlan",
       status: 410,
+    });
+
+    const paddleBillingSubmitFailure = await runSdkExit(
+      payment.submitPaymentChangePlan({
+        coupon_code: "BAD",
+        plan_path: "pro/monthly",
+      }),
+      () =>
+        jsonResponse(
+          {
+            error_message: "Coupon is invalid.",
+            error_type: "PADDLE_BILLING_INVALID_COUPON",
+            status_code: 400,
+          },
+          { status: 400 },
+        ),
+      { accessToken: "token-123" },
+    );
+
+    const paddleBillingSubmitError = expectFailure(paddleBillingSubmitFailure);
+    expect(paddleBillingSubmitError).toBeInstanceOf(PutioOperationError);
+    expect(paddleBillingSubmitError).toMatchObject({
+      _tag: "PutioOperationError",
+      domain: "payment",
+      operation: "submitChangePlan",
+      reason: {
+        errorType: "PADDLE_BILLING_INVALID_COUPON",
+        kind: "error_type",
+      },
+      status: 400,
+    });
+
+    const invoiceFailure = await runSdkExit(
+      payment.getPaddleBillingInvoiceUrl(123),
+      () =>
+        jsonResponse(
+          {
+            error_message: "Cannot find Paddle Billing payment.",
+            error_type: "PADDLE_BILLING_PAYMENT_NOT_FOUND",
+            status_code: 404,
+          },
+          { status: 404 },
+        ),
+      { accessToken: "token-123" },
+    );
+
+    const invoiceError = expectFailure(invoiceFailure);
+    expect(invoiceError).toBeInstanceOf(PutioOperationError);
+    expect(invoiceError).toMatchObject({
+      _tag: "PutioOperationError",
+      domain: "payment",
+      operation: "getPaddleBillingInvoiceUrl",
+      status: 404,
+    });
+
+    const updateFailure = await runSdkExit(
+      payment.createPaddleBillingUpdatePaymentMethodTransaction(456),
+      () =>
+        jsonResponse(
+          {
+            error_message: "Paddle Billing subscription is canceled.",
+            error_type: "PADDLE_BILLING_SUBSCRIPTION_CANCELED",
+            status_code: 404,
+          },
+          { status: 404 },
+        ),
+      { accessToken: "token-123" },
+    );
+
+    const updateError = expectFailure(updateFailure);
+    expect(updateError).toBeInstanceOf(PutioOperationError);
+    expect(updateError).toMatchObject({
+      _tag: "PutioOperationError",
+      domain: "payment",
+      operation: "createPaddleBillingUpdatePaymentMethodTransaction",
+      status: 404,
     });
   });
 });

--- a/src/domains/payment.ts
+++ b/src/domains/payment.ts
@@ -15,11 +15,11 @@ export const PaymentPlanTypeSchema = Schema.Literals(["onetime", "subscription"]
 export const PaymentOptionPlanTypeSchema = Schema.Literals(["onetime", "subscription", "trial"]);
 export const PaymentProviderNameSchema = Schema.Literals([
   "Paddle",
+  "Paddle Billing",
   "Fastspring",
   "OpenNode",
-  "AcceptNano",
 ]);
-export const PaymentTypeSchema = Schema.Literals(["credit-card", "cryptocurrency", "nano"]);
+export const PaymentTypeSchema = Schema.Literals(["credit-card", "cryptocurrency"]);
 export const UserSubscriptionStatusSchema = Schema.Literals([
   "ACTIVE",
   "CANCELED",
@@ -149,6 +149,9 @@ const PaymentChangePlanProviderPaddlePreviewSchema = Schema.Struct({
   currency: Schema.String,
   next_billing_date: Schema.NullOr(Schema.String),
 });
+const PaymentChangePlanProviderPaddleBillingPreviewSchema = Schema.Struct({
+  next_billing_date: Schema.NullOr(Schema.String),
+});
 const PaymentChangePlanProviderFastspringPreviewSchema = Schema.Struct({
   charge_amount: Schema.NullOr(Schema.String),
   currency: Schema.String,
@@ -162,6 +165,7 @@ const PaymentChangePlanDiscountSchema = Schema.Struct({
 export const PaymentChangePlanPreviewSchema = Schema.Struct({
   Fastspring: PaymentChangePlanProviderFastspringPreviewSchema,
   Paddle: PaymentChangePlanProviderPaddlePreviewSchema,
+  "Paddle Billing": PaymentChangePlanProviderPaddleBillingPreviewSchema,
   amount: Schema.NullOr(Schema.String),
   charge_amount: Schema.Boolean,
   credit: Schema.NullOr(Schema.String),
@@ -180,6 +184,11 @@ const PaddlePaymentProviderSchema = Schema.Struct({
   type: Schema.Literal("credit-card"),
   vendor_id: Schema.Int.check(Schema.isGreaterThan(0)),
 });
+const PaddleBillingPaymentProviderSchema = Schema.Struct({
+  price_id: Schema.NullOr(Schema.String),
+  provider: Schema.Literal("Paddle Billing"),
+  type: Schema.Literal("credit-card"),
+});
 const FastspringPaymentProviderSchema = Schema.Struct({
   provider: Schema.Literal("Fastspring"),
   type: Schema.Literal("credit-card"),
@@ -190,19 +199,10 @@ const OpenNodePaymentProviderSchema = Schema.Struct({
   provider: Schema.Literal("OpenNode"),
   type: Schema.Literal("cryptocurrency"),
 });
-const AcceptNanoPaymentProviderSchema = Schema.Struct({
-  amount: Schema.String,
-  api_host: Schema.String,
-  currency: Schema.Literal("USD"),
-  discount_percent: Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)),
-  provider: Schema.Literal("AcceptNano"),
-  state: Schema.String,
-  type: Schema.Literal("nano"),
-});
 export const PaymentProviderSchema = Schema.Union([
-  AcceptNanoPaymentProviderSchema,
   FastspringPaymentProviderSchema,
   OpenNodePaymentProviderSchema,
+  PaddleBillingPaymentProviderSchema,
   PaddlePaymentProviderSchema,
 ]);
 const PaymentChangePlanCheckoutSchema = Schema.Struct({
@@ -235,6 +235,14 @@ const PaymentFastspringConfirmEnvelopeSchema = Schema.Struct({
   confirmed: Schema.Boolean,
   status: Schema.Literal("OK"),
 });
+const PaymentPaddleBillingInvoiceEnvelopeSchema = Schema.Struct({
+  status: Schema.optional(Schema.Literal("OK")),
+  url: Schema.String,
+});
+const PaymentPaddleBillingUpdatePaymentMethodEnvelopeSchema = Schema.Struct({
+  status: Schema.optional(Schema.Literal("OK")),
+  transaction_id: Schema.String,
+});
 const PaymentVoucherPlanSchema = Schema.Struct({
   expiration_date: Schema.NullOr(Schema.String),
   type: Schema.NullOr(PaymentPlanTypeSchema),
@@ -252,12 +260,6 @@ export const PaymentVoucherInfoSchema = Schema.Struct({
   new_remaining_days: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   status: Schema.Literal("OK"),
   target_plan: PaymentVoucherTargetPlanSchema,
-});
-const PaymentNanoRequestEnvelopeSchema = Schema.Struct({
-  nano: Schema.Struct({
-    token: Schema.String,
-  }),
-  status: Schema.Literal("OK"),
 });
 const PaymentOpenNodeChargeEnvelopeSchema = Schema.Struct({
   opennode: Schema.Struct({
@@ -352,6 +354,8 @@ export const SubmitPaymentChangePlanErrorSpec = definePutioOperationErrorSpec({
   operation: "submitChangePlan",
   knownErrors: [
     { errorType: "PADDLE_ERROR", statusCode: 400 as const },
+    { errorType: "PADDLE_BILLING_INVALID_COUPON", statusCode: 400 as const },
+    { errorType: "PADDLE_BILLING_SUBSCRIPTION_CANNOT_CHANGE_PLAN", statusCode: 400 as const },
     { errorType: "CONFIRMATION_NOT_FOUND", statusCode: 404 as const },
     { errorType: "INVALID_CONFIRMATION", statusCode: 400 as const },
     { errorType: "PAYMENT_COUPON_CODE_NO_LONGER_AVAILABLE", statusCode: 410 as const },
@@ -430,6 +434,27 @@ export const CreatePaddleWaitingPaymentErrorSpec = definePutioOperationErrorSpec
     { statusCode: 404 as const },
   ],
 });
+export const GetPaddleBillingInvoiceUrlErrorSpec = definePutioOperationErrorSpec({
+  domain: "payment",
+  operation: "getPaddleBillingInvoiceUrl",
+  knownErrors: [
+    { errorType: "PADDLE_BILLING_PAYMENT_NOT_FOUND", statusCode: 404 as const },
+    { errorType: "PADDLE_BILLING_INVOICE_NOT_AVAILABLE", statusCode: 404 as const },
+    ...CommonPaymentActionErrors,
+    { statusCode: 404 as const },
+  ],
+});
+export const CreatePaddleBillingUpdatePaymentMethodTransactionErrorSpec =
+  definePutioOperationErrorSpec({
+    domain: "payment",
+    operation: "createPaddleBillingUpdatePaymentMethodTransaction",
+    knownErrors: [
+      { errorType: "PADDLE_BILLING_SUBSCRIPTION_NOT_FOUND", statusCode: 404 as const },
+      { errorType: "PADDLE_BILLING_SUBSCRIPTION_CANCELED", statusCode: 404 as const },
+      ...CommonPaymentActionErrors,
+      { statusCode: 404 as const },
+    ],
+  });
 export const CreateCoinbaseChargeErrorSpec = definePutioOperationErrorSpec({
   domain: "payment",
   operation: "createCoinbaseCharge",
@@ -442,15 +467,6 @@ export const CreateCoinbaseChargeErrorSpec = definePutioOperationErrorSpec({
 export const CreateOpenNodeChargeErrorSpec = definePutioOperationErrorSpec({
   domain: "payment",
   operation: "createOpenNodeCharge",
-  knownErrors: [
-    { errorType: "PAYMENT_UNKNOWN_PLAN", statusCode: 400 as const },
-    ...CommonPaymentActionErrors,
-    { statusCode: 400 as const },
-  ],
-});
-export const CreateNanoPaymentRequestErrorSpec = definePutioOperationErrorSpec({
-  domain: "payment",
-  operation: "createNanoPaymentRequest",
   knownErrors: [
     { errorType: "PAYMENT_UNKNOWN_PLAN", statusCode: 400 as const },
     ...CommonPaymentActionErrors,
@@ -480,11 +496,14 @@ export type ReportPaymentsError = PutioOperationFailure<typeof ReportPaymentsErr
 export type CreatePaddleWaitingPaymentError = PutioOperationFailure<
   typeof CreatePaddleWaitingPaymentErrorSpec
 >;
+export type GetPaddleBillingInvoiceUrlError = PutioOperationFailure<
+  typeof GetPaddleBillingInvoiceUrlErrorSpec
+>;
+export type CreatePaddleBillingUpdatePaymentMethodTransactionError = PutioOperationFailure<
+  typeof CreatePaddleBillingUpdatePaymentMethodTransactionErrorSpec
+>;
 export type CreateCoinbaseChargeError = PutioOperationFailure<typeof CreateCoinbaseChargeErrorSpec>;
 export type CreateOpenNodeChargeError = PutioOperationFailure<typeof CreateOpenNodeChargeErrorSpec>;
-export type CreateNanoPaymentRequestError = PutioOperationFailure<
-  typeof CreateNanoPaymentRequestErrorSpec
->;
 export type ClassifiedPaymentChangePlanSubmitResponse =
   | {
       readonly data: Schema.Schema.Type<typeof PaymentChangePlanCheckoutSchema>;
@@ -655,6 +674,25 @@ export const createPaddleWaitingPayment = (
     method: "POST",
     path: "/v2/payment/paddle_waiting_payment",
   }).pipe(Effect.asVoid, withOperationErrors(CreatePaddleWaitingPaymentErrorSpec));
+export const getPaddleBillingInvoiceUrl = (
+  paymentId: number,
+): Effect.Effect<string, GetPaddleBillingInvoiceUrlError, PutioSdkContext> =>
+  requestJson(PaymentPaddleBillingInvoiceEnvelopeSchema, {
+    method: "GET",
+    path: `/v2/payment/methods/paddle_billing/invoice/${encodeURIComponent(paymentId)}`,
+  }).pipe(selectJsonField("url"), withOperationErrors(GetPaddleBillingInvoiceUrlErrorSpec));
+export const createPaddleBillingUpdatePaymentMethodTransaction = (
+  userSubscriptionId: number,
+): Effect.Effect<string, CreatePaddleBillingUpdatePaymentMethodTransactionError, PutioSdkContext> =>
+  requestJson(PaymentPaddleBillingUpdatePaymentMethodEnvelopeSchema, {
+    method: "GET",
+    path: `/v2/payment/methods/paddle_billing/update_payment_method/${encodeURIComponent(
+      userSubscriptionId,
+    )}`,
+  }).pipe(
+    selectJsonField("transaction_id"),
+    withOperationErrors(CreatePaddleBillingUpdatePaymentMethodTransactionErrorSpec),
+  );
 export const createCoinbaseCharge = (
   planPath: string,
 ): Effect.Effect<string, CreateCoinbaseChargeError, PutioSdkContext> =>
@@ -688,21 +726,4 @@ export const createOpenNodeCharge = (
     selectJsonField("opennode"),
     Effect.map(({ checkout_url }) => checkout_url),
     withOperationErrors(CreateOpenNodeChargeErrorSpec),
-  );
-export const createNanoPaymentRequest = (
-  planCode: string,
-): Effect.Effect<string, CreateNanoPaymentRequestError, PutioSdkContext> =>
-  requestJson(PaymentNanoRequestEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: {
-        plan_code: planCode,
-      },
-    },
-    method: "POST",
-    path: "/v2/payment/methods/nano/request",
-  }).pipe(
-    selectJsonField("nano"),
-    Effect.map(({ token }) => token),
-    withOperationErrors(CreateNanoPaymentRequestErrorSpec),
   );

--- a/test/live/domains/payment.ts
+++ b/test/live/domains/payment.ts
@@ -399,22 +399,6 @@ await run("payment opennode invalid plan yields typed 400", async () => {
   }
 });
 
-await run("payment nano invalid plan yields typed 400", async () => {
-  await getOwnerPaymentInfo();
-
-  try {
-    await ownerClient.payment.methods.createNanoPaymentRequest("");
-    throw new Error("expected createNanoPaymentRequest to fail");
-  } catch (error) {
-    return assertOperationError(error, {
-      domain: "payment",
-      operation: "createNanoPaymentRequest",
-      errorType: "PAYMENT_UNKNOWN_PLAN",
-      statusCode: 400,
-    });
-  }
-});
-
 await run("payment sub-account preview is rejected", async () => {
   const subAccountClient = await getSubAccountClient();
 


### PR DESCRIPTION
## Summary

Remove the deprecated AcceptNano/Nano checkout surface and align the TypeScript SDK payment contracts with current Paddle Billing backend responses.

## Changed

- Remove `AcceptNano`, `nano`, and `payment.methods.createNanoPaymentRequest` from the public SDK surface.
- Add `Paddle Billing` provider parsing for change-plan checkout URLs with `price_id`.
- Add Paddle Billing preview support for `Paddle Billing.next_billing_date`.
- Add Paddle Billing invoice URL and update-payment-method transaction helpers to the Effect and Promise clients.
- Add typed Paddle Billing operation errors for submit, invoice lookup, and update-payment-method flows.

## Risks

Breaking change for SDK consumers that still call the old Nano checkout method or rely on Nano provider/type literals. Paddle Billing `price_id` can be `null`, matching backend rollout state; consumers should check for a usable string before opening checkout.

## Verification

- `vp check .`
- `vp test run src/domains/payment.spec.ts src/core/client.promise.spec.ts --passWithNoTests`
- `vp run verify`
- `pnpm lint:package`
- `autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings

## Complexity

Reduced overall: removes dead Nano checkout code while adding the small Paddle Billing contract surface needed by the current backend.