### PR TITLE
feat(account): list subtitle languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you create a long-lived Promise client in a script, test harness, or server i
 
 | Namespace       | Purpose                                                                    |
 | --------------- | -------------------------------------------------------------------------- |
-| `account`       | account info, settings, confirmations, destructive account actions         |
+| `account`       | account info, settings, subtitle languages, confirmations, clear/destroy   |
 | `auth`          | token validation, login flows, device/OOB helpers, two-factor flows        |
 | `config`        | app-owned JSON config storage                                              |
 | `downloadLinks` | download-link bundles                                                      |

--- a/scripts/test-compat-node.mts
+++ b/scripts/test-compat-node.mts
@@ -65,6 +65,13 @@ import { toHumanFileSize } from "@putdotio/sdk/utilities";
 const promiseClient: PutioSdkPromiseClient = createPutioSdkPromiseClient({
   accessToken: "compat-token",
 });
+type SubtitleLanguages = Awaited<
+  ReturnType<PutioSdkPromiseClient["account"]["listSubtitleLanguages"]>
+>;
+const subtitleLanguage: SubtitleLanguages[number] = {
+  code: "eng",
+  name: "English",
+};
 const promiseAuthUrl = promiseClient.auth.buildLoginUrl({
   clientId: "external-node",
   redirectUri: "https://example.com/callback",
@@ -94,6 +101,7 @@ console.log(
   JSON.stringify({
     effectAuthHost,
     promiseAuthHost,
+    subtitleLanguage: subtitleLanguage.code,
     uploadMethod: uploadRequest.method,
     uploadBody: uploadRequest.body.constructor.name,
     utility: toHumanFileSize(1_572_864),

--- a/src/core/client.promise.spec.ts
+++ b/src/core/client.promise.spec.ts
@@ -8,6 +8,7 @@ vi.mock("../domains/account.js", async () => {
     destroyAccount: vi.fn((password) => Effect.succeed({ destroyed: password })),
     getAccountInfo: vi.fn((query) => Effect.succeed({ id: 1, query, username: "sdk-user" })),
     getAccountSettings: vi.fn(() => Effect.succeed({ locale: "en" })),
+    listAccountSubtitleLanguages: vi.fn(() => Effect.succeed([{ code: "eng", name: "English" }])),
     listAccountConfirmations: vi.fn((subject) => Effect.succeed([{ subject }])),
     saveAccountSettings: vi.fn((payload) => Effect.succeed({ saved: payload })),
   };
@@ -501,6 +502,9 @@ describe("sdk promise client adapters", () => {
     expect(await client.account.destroy("secret")).toEqual({ destroyed: "secret" });
     expect(await client.account.getInfo({ download_token: 1 })).toMatchObject({ id: 1 });
     expect(await client.account.getSettings()).toEqual({ locale: "en" });
+    expect(await client.account.listSubtitleLanguages()).toEqual([
+      { code: "eng", name: "English" },
+    ]);
     expect(await client.account.listConfirmations("mail_change")).toEqual([
       { subject: "mail_change" },
     ]);

--- a/src/core/client.spec.ts
+++ b/src/core/client.spec.ts
@@ -37,6 +37,7 @@ describe("sdk client factories", () => {
     const client = createPutioSdkEffectClient();
 
     expect(client.account.getInfo).toBeTypeOf("function");
+    expect(client.account.listSubtitleLanguages).toBeTypeOf("function");
     expect(client.auth.getCode).toBeTypeOf("function");
     expect(client.downloadLinks.create).toBeTypeOf("function");
     expect(client.events.list).toBeTypeOf("function");
@@ -89,6 +90,7 @@ describe("sdk client factories", () => {
 
     expect(client.dispose).toBeTypeOf("function");
     expect(client.account.getInfo).toBeTypeOf("function");
+    expect(client.account.listSubtitleLanguages).toBeTypeOf("function");
     expect(client.auth.getCode).toBeTypeOf("function");
     expect(client.files.createUploadFormData).toBeTypeOf("function");
     expect(client.files.getApiDownloadUrl).toBeTypeOf("function");

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -5,11 +5,13 @@ import {
   destroyAccount,
   getAccountInfo,
   getAccountSettings,
+  listAccountSubtitleLanguages,
   listAccountConfirmations,
   saveAccountSettings,
   type AccountInfoBase,
   type AccountInfoQuery,
   type AccountSettings,
+  type AccountSubtitleLanguage,
   type AccountConfirmation,
   type AccountInfoBroad,
   type PasInfo,
@@ -348,6 +350,7 @@ export const createPutioSdkEffectClient = () => ({
     destroy: destroyAccount,
     getInfo: getAccountInfo,
     getSettings: getAccountSettings,
+    listSubtitleLanguages: listAccountSubtitleLanguages,
     listConfirmations: listAccountConfirmations,
     saveSettings: saveAccountSettings,
   },
@@ -648,6 +651,8 @@ export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape =
       destroy: (currentPassword: string) => provideSdk(config, destroyAccount(currentPassword)),
       getInfo,
       getSettings: (): Promise<AccountSettings> => provideSdk(config, getAccountSettings()),
+      listSubtitleLanguages: (): Promise<ReadonlyArray<AccountSubtitleLanguage>> =>
+        provideSdk(config, listAccountSubtitleLanguages()),
       listConfirmations: (subject?: AccountConfirmation["subject"]) =>
         provideSdk(config, listAccountConfirmations(subject)),
       saveSettings: (payload: SaveAccountSettingsPayload) =>

--- a/src/domains/account.spec.ts
+++ b/src/domains/account.spec.ts
@@ -4,6 +4,7 @@ import {
   destroyAccount,
   getAccountInfo,
   getAccountSettings,
+  listAccountSubtitleLanguages,
   listAccountConfirmations,
   saveAccountSettings,
 } from "./account.js";
@@ -200,6 +201,41 @@ describe("account domain", () => {
     );
 
     expect(result).toEqual({ status: "OK" });
+  });
+
+  it("lists supported subtitle languages", async () => {
+    const languages = await runSdkEffect(
+      listAccountSubtitleLanguages(),
+      (request) => {
+        expect(request.url).toBe("https://api.put.io/v2/account/subtitle_languages");
+
+        return jsonResponse({
+          languages: [
+            { code: "eng", name: "English" },
+            { code: "tur", name: "Turkish" },
+          ],
+          status: "OK",
+        });
+      },
+      { accessToken: "token-123" },
+    );
+
+    expect(languages).toEqual([
+      { code: "eng", name: "English" },
+      { code: "tur", name: "Turkish" },
+    ]);
+
+    const invalidExit = await runSdkExit(
+      listAccountSubtitleLanguages(),
+      () =>
+        jsonResponse({
+          languages: [{ code: "eng" }],
+          status: "OK",
+        }),
+      { accessToken: "token-123" },
+    );
+
+    expect(expectFailure(invalidExit)).toBeInstanceOf(PutioValidationError);
   });
 
   it("maps account operation failures and form mutations", async () => {

--- a/src/domains/account.ts
+++ b/src/domains/account.ts
@@ -103,6 +103,14 @@ const AccountSettingsEnvelopeSchema = Schema.Struct({
   settings: AccountSettingsSchema,
   status: Schema.Literal("OK"),
 });
+export const AccountSubtitleLanguageSchema = Schema.Struct({
+  code: Schema.String,
+  name: Schema.String,
+});
+const AccountSubtitleLanguagesEnvelopeSchema = Schema.Struct({
+  languages: Schema.Array(AccountSubtitleLanguageSchema),
+  status: Schema.Literal("OK"),
+});
 export const AccountTwoFactorSettingsSchema = Schema.Struct({
   code: Schema.String,
   enable: Schema.Boolean,
@@ -182,6 +190,7 @@ export type SaveAccountSettingsPayload = Schema.Schema.Type<
 >;
 export type AccountClearOptions = Schema.Schema.Type<typeof AccountClearOptionsSchema>;
 export type AccountConfirmation = Schema.Schema.Type<typeof AccountConfirmationSchema>;
+export type AccountSubtitleLanguage = Schema.Schema.Type<typeof AccountSubtitleLanguageSchema>;
 export type AccountInfoResponseFor<TQuery extends AccountInfoQuery> = AccountInfoBase &
   (TQuery["download_token"] extends 1
     ? {
@@ -391,6 +400,15 @@ export const getAccountSettings = (): Effect.Effect<
     method: "GET",
     path: "/v2/account/settings",
   }).pipe(selectJsonField("settings"));
+export const listAccountSubtitleLanguages = (): Effect.Effect<
+  ReadonlyArray<AccountSubtitleLanguage>,
+  PutioSdkError,
+  PutioSdkContext
+> =>
+  requestJson(AccountSubtitleLanguagesEnvelopeSchema, {
+    method: "GET",
+    path: "/v2/account/subtitle_languages",
+  }).pipe(selectJsonField("languages"));
 export const saveAccountSettings = (
   payload: SaveAccountSettingsPayload,
 ): Effect.Effect<

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -14,6 +14,7 @@ describe("sdk root entry", () => {
       createPutioSdkEffectClient: expect.any(Function),
       createPutioSdkPromiseClient: expect.any(Function),
       getAccountInfo: expect.any(Function),
+      listAccountSubtitleLanguages: expect.any(Function),
       getCode: expect.any(Function),
       getConfigKey: expect.any(Function),
       getFile: expect.any(Function),
@@ -37,7 +38,12 @@ describe("sdk root entry", () => {
     });
 
     expect(Object.keys(sdk)).toEqual(
-      expect.arrayContaining(["getAccountInfo", "getFile", "uploadFile"]),
+      expect.arrayContaining([
+        "getAccountInfo",
+        "getFile",
+        "listAccountSubtitleLanguages",
+        "uploadFile",
+      ]),
     );
   });
 });

--- a/test/live/account.test.ts
+++ b/test/live/account.test.ts
@@ -34,6 +34,16 @@ describe.sequential("account live", () => {
     ).toBe(true);
   });
 
+  test("supported subtitle languages expose stable code and name fields", async () => {
+    const languages = await clients.oauthClient.account.listSubtitleLanguages();
+
+    expect(languages.length).toBeGreaterThan(0);
+    expect(languages).toContainEqual({ code: "eng", name: "English" });
+    expect(
+      languages.every((language) => language.code.length > 0 && language.name.length > 0),
+    ).toBe(true);
+  });
+
   test("account settings theme mutation is reversible", async () => {
     const before = await clients.authClient.account.getSettings();
     const nextTheme = before.theme === "dark" ? "auto" : "dark";


### PR DESCRIPTION
## Summary

- add a schema-validated account subtitle-language catalog operation
- expose `account.listSubtitleLanguages()` on both Effect and Promise clients
- cover domain decoding, malformed responses, public exports, client parity, live behavior, and packed consumer types

## Review aids

Sanitized contract mapping:

```json
GET /v2/account/subtitle_languages
{ "status": "OK", "languages": [{ "code": "eng", "name": "English" }] }
```

```ts
await sdk.account.listSubtitleLanguages();
// [{ code: "eng", name: "English" }]
```

## Risks

- The route is absent from the current public Swagger definition. The contract is sourced from the current backend route, language serializer, and `ApiBlueprint` response wrapper, plus the existing putio-web consumer.
- The added live test is read-only. It was not run locally because this task was kept credential-free.
- Existing advisory Knip baselines remain: the untouched `origin/main` also reports the `vite-plus` catalog/`op` ignore metadata and production-mode `effect` findings.

## Verification

- `vp install --frozen-lockfile`
- `pnpm exec vp run verify` — 91 tests; 98.58% statements, 91.47% branches
- `pnpm lint:package`
- `pnpm test:compat` — packed Node TypeScript/runtime, Chromium, Firefox, WebKit, and Bun
- `git diff --check`
- structured Codex autoreview — clean, no actionable findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `account.listSubtitleLanguages()` to fetch supported subtitle languages with schema validation. Returns a typed list of `{ code, name }` for use in UI and settings.

- **New Features**
  - Implemented GET `/v2/account/subtitle_languages` in the account domain.
  - Exposed `account.listSubtitleLanguages()` on Effect and Promise clients and added root export.
  - Updated README and compat/live tests to cover the new method.

<sup>Written for commit c236cb1b81faea5433b69c30664e4b9c1c0a5ca3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

