### PR TITLE
fix(sdk): align backend response contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ The package compatibility gate installs the packed tarball into external consume
 
 Promise consumers receive tagged SDK error objects:
 
+Backend error bodies preserve `status`, `status_code`, `error_type`, `error_message`,
+`error_uri`, nullable `error_id`, and structured `extra` metadata. The legacy
+`details` field remains available for compatibility, but current backend errors use
+`extra`; `details` is planned for removal in the next major release.
+
 ```ts
 import {
   createPutioSdkPromiseClient,

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -592,14 +592,14 @@ export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape =
   }): Promise<AccountInfoBase & { readonly features: Record<string, boolean> }>;
   function getInfo(query: {
     readonly intercom: 1;
-    readonly platform?: string;
-  }): Promise<AccountInfoBase & { readonly user_hash: string }>;
+    readonly platform?: "web" | "ios";
+  }): Promise<AccountInfoBase & { readonly user_hash?: string }>;
   function getInfo(query: {
     readonly pas: 1;
   }): Promise<AccountInfoBase & { readonly pas: PasInfo }>;
   function getInfo(query: {
     readonly profitwell: 1;
-  }): Promise<AccountInfoBase & { readonly paddle_user_id: number | null }>;
+  }): Promise<AccountInfoBase & { readonly paddle_user_id: number | string | null }>;
   function getInfo(query: {
     readonly push_token: 1;
   }): Promise<AccountInfoBase & { readonly push_token: string }>;

--- a/src/core/errors.spec.ts
+++ b/src/core/errors.spec.ts
@@ -168,16 +168,24 @@ describe("sdk core errors", () => {
     const body = await Effect.runPromise(
       parseErrorBody(400, {
         details: { field: "name" },
+        error_id: null,
         error_message: "Bad request",
         error_type: "BadRequest",
+        error_uri: "http://api.put.io/v2/docs",
+        extra: { field: "name", limit: 10 },
+        status: "ERROR",
         status_code: 400,
       }),
     );
 
     expect(body).toEqual({
       details: { field: "name" },
+      error_id: null,
       error_message: "Bad request",
       error_type: "BadRequest",
+      error_uri: "http://api.put.io/v2/docs",
+      extra: { field: "name", limit: 10 },
+      status: "ERROR",
       status_code: 400,
     });
   });

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,8 +1,12 @@
 import { Data, Effect, Schema } from "effect";
 
 export const PutioErrorEnvelopeSchema = Schema.Struct({
+  status: Schema.optional(Schema.String),
   error_message: Schema.optional(Schema.String),
   error_type: Schema.optional(Schema.String),
+  error_uri: Schema.optional(Schema.String),
+  error_id: Schema.optional(Schema.NullOr(Schema.String)),
+  extra: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
   status_code: Schema.optional(Schema.Int),
   details: Schema.optional(Schema.Unknown),
 });
@@ -114,6 +118,20 @@ const hasOptionalInteger = (record: Readonly<Record<string, unknown>>, key: stri
   !(key in record) ||
   record[key] === undefined ||
   (typeof record[key] === "number" && Number.isInteger(record[key]));
+
+const hasOptionalNullableString = (
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): boolean =>
+  !(key in record) ||
+  record[key] === undefined ||
+  record[key] === null ||
+  typeof record[key] === "string";
+
+const hasOptionalRecord = (record: Readonly<Record<string, unknown>>, key: string): boolean =>
+  !(key in record) ||
+  record[key] === undefined ||
+  (isRecord(record[key]) && !Array.isArray(record[key]));
 
 const isKnownOperationErrorContract = (value: unknown): value is PutioKnownOperationErrorContract =>
   isRecord(value) &&
@@ -253,8 +271,12 @@ export const decodePutioErrorEnvelope = Schema.decodeUnknownEffect(PutioErrorEnv
 
 export const isPutioErrorEnvelope = (value: unknown): value is PutioErrorEnvelope =>
   isRecord(value) &&
+  hasOptionalString(value, "status") &&
   hasOptionalString(value, "error_message") &&
   hasOptionalString(value, "error_type") &&
+  hasOptionalString(value, "error_uri") &&
+  hasOptionalNullableString(value, "error_id") &&
+  hasOptionalRecord(value, "extra") &&
   hasOptionalInteger(value, "status_code");
 
 const hasStatusAndBody = <TTag extends string>(

--- a/src/domains/account.spec.ts
+++ b/src/domains/account.spec.ts
@@ -115,7 +115,7 @@ describe("account domain", () => {
             features: {
               beta: true,
             },
-            paddle_user_id: 99,
+            paddle_user_id: "ctm_99",
             user_hash: "intercom-user",
           },
           status: "OK",
@@ -126,7 +126,21 @@ describe("account domain", () => {
 
     expect(fullInfo.features.beta).toBe(true);
     expect(fullInfo.user_hash).toBe("intercom-user");
-    expect(fullInfo.paddle_user_id).toBe(99);
+    expect(fullInfo.paddle_user_id).toBe("ctm_99");
+
+    const intercomInfo = await runSdkEffect(
+      getAccountInfo({
+        intercom: 1,
+        platform: "ios",
+      }),
+      (request) => {
+        expect(request.url).toBe("https://api.put.io/v2/account/info?intercom=1&platform=ios");
+        return jsonResponse({ info: baseAccountInfo, status: "OK" });
+      },
+      { accessToken: "token-123" },
+    );
+
+    expect(intercomInfo.user_hash).toBeUndefined();
 
     const exit = await runSdkExit(
       getAccountInfo({
@@ -149,7 +163,6 @@ describe("account domain", () => {
 
     for (const [query, expectedCause] of [
       [{ features: 1 }, 'Expected put.io to include "features" because it was requested'],
-      [{ intercom: 1 }, 'Expected put.io to include "user_hash" because it was requested'],
       [{ profitwell: 1 }, 'Expected put.io to include "paddle_user_id" because it was requested'],
     ] as const) {
       const missingExit = await runSdkExit(

--- a/src/domains/account.ts
+++ b/src/domains/account.ts
@@ -81,7 +81,7 @@ export const AccountInfoQuerySchema = Schema.Struct({
   features: Schema.optional(RequestedFlag),
   intercom: Schema.optional(RequestedFlag),
   pas: Schema.optional(RequestedFlag),
-  platform: Schema.optional(Schema.String),
+  platform: Schema.optional(Schema.Literals(["web", "ios"])),
   profitwell: Schema.optional(RequestedFlag),
   push_token: Schema.optional(RequestedFlag),
 });
@@ -89,7 +89,7 @@ export const AccountInfoBroadSchema = AccountInfoBaseSchema.pipe(
   Schema.fieldsAssign({
     download_token: Schema.optional(Schema.String),
     features: Schema.optional(AccountFeaturesSchema),
-    paddle_user_id: Schema.optional(Schema.NullOr(Schema.Int)),
+    paddle_user_id: Schema.optional(Schema.NullOr(Schema.Union([Schema.Int, Schema.String]))),
     pas: Schema.optional(PasInfoSchema),
     push_token: Schema.optional(Schema.String),
     user_hash: Schema.optional(Schema.String),
@@ -204,7 +204,7 @@ export type AccountInfoResponseFor<TQuery extends AccountInfoQuery> = AccountInf
     : {}) &
   (TQuery["intercom"] extends 1
     ? {
-        readonly user_hash: string;
+        readonly user_hash?: string;
       }
     : {}) &
   (TQuery["pas"] extends 1
@@ -214,7 +214,7 @@ export type AccountInfoResponseFor<TQuery extends AccountInfoQuery> = AccountInf
     : {}) &
   (TQuery["profitwell"] extends 1
     ? {
-        readonly paddle_user_id: number | null;
+        readonly paddle_user_id: number | string | null;
       }
     : {}) &
   (TQuery["push_token"] extends 1
@@ -241,11 +241,6 @@ const hasFeatures = (
 ): value is AccountInfoBroad & {
   readonly features: Record<string, boolean>;
 } => typeof value.features === "object" && value.features !== null;
-const hasIntercomUserHash = (
-  value: AccountInfoBroad,
-): value is AccountInfoBroad & {
-  readonly user_hash: string;
-} => typeof value.user_hash === "string";
 const hasPas = (
   value: AccountInfoBroad,
 ): value is AccountInfoBroad & {
@@ -254,7 +249,7 @@ const hasPas = (
 const hasPaddleUserId = (
   value: AccountInfoBroad,
 ): value is AccountInfoBroad & {
-  readonly paddle_user_id: number | null;
+  readonly paddle_user_id: number | string | null;
 } => "paddle_user_id" in value;
 const hasPushToken = (
   value: AccountInfoBroad,
@@ -276,9 +271,6 @@ const ensureAccountInfoFields = <TQuery extends AccountInfoQuery>(
     }
     if (query.features === 1 && !hasFeatures(info)) {
       return yield* failMissingField("features");
-    }
-    if (query.intercom === 1 && !hasIntercomUserHash(info)) {
-      return yield* failMissingField("user_hash");
     }
     if (query.pas === 1 && !hasPas(info)) {
       return yield* failMissingField("pas");
@@ -350,10 +342,10 @@ export function getAccountInfo(query: { readonly features: 1 }): Effect.Effect<
 >;
 export function getAccountInfo(query: {
   readonly intercom: 1;
-  readonly platform?: string;
+  readonly platform?: "web" | "ios";
 }): Effect.Effect<
   AccountInfoBase & {
-    readonly user_hash: string;
+    readonly user_hash?: string;
   },
   PutioSdkError,
   PutioSdkContext
@@ -367,7 +359,7 @@ export function getAccountInfo(query: { readonly pas: 1 }): Effect.Effect<
 >;
 export function getAccountInfo(query: { readonly profitwell: 1 }): Effect.Effect<
   AccountInfoBase & {
-    readonly paddle_user_id: number | null;
+    readonly paddle_user_id: number | string | null;
   },
   PutioSdkError,
   PutioSdkContext

--- a/src/domains/files.spec.ts
+++ b/src/domains/files.spec.ts
@@ -600,6 +600,14 @@ describe("files domain", () => {
 
     expect(
       await runSdkEffect(
+        files.getMp4Status(9),
+        () => jsonResponse({ mp4: { id: 9, status: "IN_QUEUE" }, status: "OK" }),
+        { accessToken: "token-123" },
+      ),
+    ).toEqual({ id: 9, status: "IN_QUEUE" });
+
+    expect(
+      await runSdkEffect(
         files.convertFileToMp4(9),
         () => jsonResponse({ mp4: { id: 9, status: "NOT_AVAILABLE" }, status: "OK" }),
         { accessToken: "token-123" },

--- a/src/domains/files.ts
+++ b/src/domains/files.ts
@@ -212,7 +212,7 @@ const FileConversionNotAvailableSchema = Schema.Struct({
 });
 const FileConversionInQueueSchema = Schema.Struct({
   id: Schema.Int,
-  percent_done: Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)),
+  percent_done: Schema.optional(Schema.Number.check(Schema.isGreaterThanOrEqualTo(0))),
   status: Schema.Literal("IN_QUEUE"),
 });
 const FileConversionConvertingSchema = Schema.Struct({


### PR DESCRIPTION
## Summary

Align additive SDK response and error contracts with the current put.io backend.

Part of #108. This is 1/4 in stack #111; #110, #119, and #120 build on this PR.

## Changed

- accept numeric, string, or null `paddle_user_id` values on Effect and Promise clients
- restrict Intercom platform values to `web | ios` and make `user_hash` optional when backend secrets are unavailable
- accept queued MP4 responses that omit `percent_done`
- preserve backend `status`, `error_uri`, nullable `error_id`, and structured `extra` error fields
- retain `details` as deprecated compatibility surface until the next major release

## Review aids

Representative backend payloads newly accepted without weakening unrelated variants:

```json
{ "info": { "paddle_user_id": "ctm_123" } }
{ "info": {} }
{ "mp4": { "id": 9, "status": "IN_QUEUE" } }
{
  "status": "ERROR",
  "status_code": 400,
  "error_type": "BadRequest",
  "error_uri": "http://api.put.io/v2/docs",
  "error_id": null,
  "extra": { "limit": 10 }
}
```

The empty account-info sample applies to an `intercom=1` request when backend Intercom configuration is absent.

## Risks

- public response types are broadened to match valid backend values; no symbols are removed
- consumers that assumed requested Intercom hashes were always present must now handle `undefined`

## Verification

- canonical verify passed: 91 unit tests and coverage thresholds
- package declarations, publint, and Are The Types Wrong passed
- packed consumer compatibility passed in Node, Chromium, Firefox, WebKit, and Bun

## Complexity

Low. Existing schemas and conditional overloads are corrected in place; no new abstraction or runtime service is introduced.