### PR TITLE
fix(files): use canonical playback progress routes

### DIFF
--- a/src/domains/files.spec.ts
+++ b/src/domains/files.spec.ts
@@ -576,6 +576,8 @@ describe("files domain", () => {
           time: 12.5,
         }),
         (request) => {
+          expect(request.method).toBe("POST");
+          expect(request.url).toBe("https://api.put.io/v2/files/9/start-from");
           expect(getFormBody(request).get("time")).toBe("12.5");
           return jsonResponse({ status: "OK" });
         },
@@ -584,9 +586,17 @@ describe("files domain", () => {
     ).toEqual({ status: "OK" });
 
     expect(
-      await runSdkEffect(files.resetStartFrom(9), () => jsonResponse({ status: "OK" }), {
-        accessToken: "token-123",
-      }),
+      await runSdkEffect(
+        files.resetStartFrom(9),
+        (request) => {
+          expect(request.method).toBe("POST");
+          expect(request.url).toBe("https://api.put.io/v2/files/9/start-from/delete");
+          return jsonResponse({ status: "OK" });
+        },
+        {
+          accessToken: "token-123",
+        },
+      ),
     ).toEqual({ status: "OK" });
 
     expect(

--- a/src/domains/files.ts
+++ b/src/domains/files.ts
@@ -1093,13 +1093,13 @@ export const setStartFrom = (
       },
     },
     method: "POST",
-    path: `/v2/files/${encodePathSegment(input.file_id)}/start-from/set`,
+    path: `/v2/files/${encodePathSegment(input.file_id)}/start-from`,
   }).pipe(withOperationErrors(StartFromErrorSpec));
 export const resetStartFrom = (
   fileId: number,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, StartFromError, PutioSdkContext> =>
   requestJson(OkResponseSchema, {
-    method: "GET",
+    method: "POST",
     path: `/v2/files/${encodePathSegment(fileId)}/start-from/delete`,
   }).pipe(withOperationErrors(StartFromErrorSpec));
 export const getMp4Status = (


### PR DESCRIPTION
## Summary

Use the backend's canonical playback-progress routes for setting and clearing file position.

Part of #108. This is 2/4 in stack #111; #119 and #120 build on this PR.

## Changed

- send progress updates to POST `/v2/files/:id/start-from`
- clear progress with POST `/v2/files/:id/start-from/delete`
- assert exact HTTP method, URL, and form payload in deterministic request tests

## Review aids

| Operation | Before | After |
| --- | --- | --- |
| set progress | POST `/v2/files/:id/start-from/set` | POST `/v2/files/:id/start-from` |
| clear progress | GET `/v2/files/:id/start-from/delete` | POST `/v2/files/:id/start-from/delete` |

The backend still aliases the old set route and temporarily accepts GET for delete, so this switches the SDK to the canonical write semantics without changing the public method names.

## Risks

Low. Request paths and method are corrected; response schemas and public client signatures are unchanged.

## Verification

- exact request-shape tests passed for set and reset operations
- canonical verify passed: 91 unit tests and coverage thresholds
- package declarations, publint, and Are The Types Wrong passed
- packed consumer compatibility passed in Node, Chromium, Firefox, WebKit, and Bun

## Complexity

Low. Two request definitions and their existing deterministic tests change.