### PR TITLE
chore(knip): clean source analysis config

### DIFF
--- a/.github/actions/setup-vp/action.yml
+++ b/.github/actions/setup-vp/action.yml
@@ -18,7 +18,8 @@ runs:
       id: versions
       shell: bash
       run: |
-        version=$(jq -er '.devDependencies["vite-plus"] | sub("^[~^]"; "")' package.json)
+        version=$(sed -n 's/^  vite-plus: //p' pnpm-workspace.yaml)
+        test -n "$version"
         echo "vite-plus-version=${version}" >> "$GITHUB_OUTPUT"
 
     - name: Set up Vite+

--- a/knip.json
+++ b/knip.json
@@ -11,6 +11,5 @@
     "vitest.live.config.ts"
   ],
   "project": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.mts", "*.config.ts"],
-  "ignoreBinaries": ["op"],
   "ignoreDependencies": ["is-ci"]
 }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "publint": "^0.3.21",
     "typescript": "^7.0.2",
     "vite": "catalog:",
-    "vite-plus": "0.2.6",
+    "vite-plus": "catalog:",
     "vitest": "catalog:"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: 4.1.10
       version: 4.1.10
+    vite-plus:
+      specifier: 0.2.6
+      version: 0.2.6
 
 overrides:
   vite: npm:@voidzero-dev/vite-plus-core@0.2.6
@@ -50,7 +53,7 @@ importers:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.6
         version: '@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(jiti@2.7.0)(publint@0.3.21)(typescript@7.0.2)(yaml@2.9.0)'
       vite-plus:
-        specifier: 0.2.6
+        specifier: 'catalog:'
         version: 0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.6(@arethetypeswrong/core@0.18.5)(@types/node@26.1.1)(jiti@2.7.0)(publint@0.3.21)(typescript@7.0.2)(yaml@2.9.0))(jiti@2.7.0)(publint@0.3.21)(typescript@7.0.2)(yaml@2.9.0)
       vitest:
         specifier: 4.1.10


### PR DESCRIPTION
Part of #108.

## Summary

Make the source Knip pass and CI setup use the repository's authoritative Vite+ catalog, while removing a stale local-tool suppression.

## Changed

- resolve `vite-plus` through the root pnpm catalog
- teach the CI setup action to read the Vite+ installer version from that catalog
- remove the obsolete `op` binary exemption
- refresh the lockfile without changing the resolved Vite+ version

## Review aids

```text
package.json:          "vite-plus": "catalog:"
pnpm-workspace.yaml:   vite-plus: 0.2.6
setup-vp action:       reads 0.2.6 from pnpm-workspace.yaml
```

Stack: **#112** -> #113 -> #114.

## Risks

Low. This changes dependency metadata and static analysis configuration only. The CI action now resolves the same Vite+ 0.2.6 catalog value used by package installation.

## Verification

- catalog extraction returned Vite+ 0.2.6
- repository install completed with the lockfile state
- source Knip reported no findings
- canonical Vite+ verification passed locally

## Complexity

Low: one manifest cleanup, one stale suppression removal, one CI catalog lookup, and the corresponding lockfile update.
