### PR TITLE
chore(knip): analyze packed production output

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dev": "vp pack --watch",
     "lint:package": "vp pack && publint --pack pnpm && attw --pack . --profile esm-only",
     "lint:unused": "knip",
-    "lint:unused:prod": "vp pack && knip --production",
+    "lint:unused:prod": "vp pack && knip --production --no-gitignore",
     "prepare": "./scripts/prepare-effect.sh",
     "prepack": "vp pack",
     "secrets:setup": "bash ./scripts/secrets-setup.sh",


### PR DESCRIPTION
Part of #108.

## Summary

Make production Knip analyze the package that consumers actually receive, including the ignored `dist/**` output created by Vite+.

## Changed

- pack before the production analysis
- run Knip with `--production --no-gitignore`
- retain the explicit Knip entry/project patterns so unrelated ignored files remain outside the graph

## Review aids

```mermaid
flowchart LR
  A["vp pack"] --> B["dist/index.js + declarations"]
  B --> C["knip --production --no-gitignore"]
  C --> D["Packed dependency and reachability findings"]
```

A trace against the packed output resolves `effect` from `dist/index.js`, so the runtime dependency remains real and unsuppressed.

Stack: #112 -> **#113** -> #114.

## Risks

`--no-gitignore` can broaden analysis in a loose configuration. Here the explicit package/test/script/config patterns constrain the graph, and the production pass is green against the packed output.

## Verification

- `vp run lint:unused:prod` passed
- production Knip traced `effect` from `dist/index.js`
- Vite+ formatting and lint checks passed

## Complexity

Low: one script flag change, with the scope controlled by the existing Knip configuration.
