### PR TITLE
ci(knip): make unused-code checks blocking

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -41,16 +41,16 @@ vp test --coverage
 Additional package and cleanup checks:
 
 ```bash
-pnpm lint:unused
-pnpm lint:unused:prod
-pnpm lint:package
-pnpm test:compat
+vp run lint:unused
+vp run lint:unused:prod
+vp run lint:package
+vp run test:compat
 ```
 
 `lint:unused` runs Knip against source, tests, live tests, scripts, and config files to detect unused files, dependencies, and exports.
-`lint:unused:prod` builds the package and runs Knip's production-only graph for package-surface cleanup.
+`lint:unused:prod` packs the package, then runs Knip's production-only graph with ignored build output visible. Knip's explicit entry and project patterns keep that analysis limited to the package, tests, scripts, and root config rather than unrelated ignored files.
 `lint:package` packs the package and runs `publint` plus Are The Types Wrong against the published ESM entrypoints.
-CI runs `lint:package` after `vp run verify`; the Knip checks remain local/advisory until their baseline is stable enough to make blocking.
+`vp run verify` blocks on both Knip graphs and executes the covered unit suite once. CI follows it with `lint:package`; Knip governs source reachability and dependency usage, while package checks and explicit API/type tests govern intentional public exports.
 
 ## Runtime Compatibility Checks
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -59,21 +59,21 @@ Compatibility checks are package-consumer smoke tests, not live API tests. They 
 Run all compatibility checks:
 
 ```bash
-pnpm test:compat
+vp run test:compat
 ```
 
 Target one runtime:
 
 ```bash
-pnpm test:compat:node
-PUTIO_COMPAT_BROWSERS=chromium pnpm test:compat:browser
-pnpm test:compat:bun
+vp run test:compat:node
+PUTIO_COMPAT_BROWSERS=chromium vp run test:compat:browser
+vp run test:compat:bun
 ```
 
 The browser check uses Playwright. Install local browser engines once when needed:
 
 ```bash
-pnpm test:compat:browser:install
+vp run test:compat:browser:install
 ```
 
 The compatibility layer proves:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:compat:bun": "node ./scripts/test-compat-bun.mts",
     "test:compat:node": "node ./scripts/test-compat-node.mts",
     "test:live": "vp pack && vp test run --config vitest.live.config.ts",
-    "verify": "vp check . && vp pack && vp test --passWithNoTests && vp test run --coverage --passWithNoTests"
+    "verify": "vp check . && vp pack && knip && knip --production --no-gitignore && vp test run --coverage --passWithNoTests"
   },
   "dependencies": {
     "effect": "4.0.0-beta.101"


### PR DESCRIPTION
Part of #108.

## Summary

Promote both Knip graphs into the canonical verification gate and remove the duplicate plain unit-test run.

## Changed

- make source and packed-production Knip blocking in `vp run verify`
- execute the unit suite once under coverage instead of once plain and once covered
- document the blocking checks, packed-output behavior, and ownership boundaries between Knip and package-surface checks

## Review aids

```mermaid
flowchart LR
  A["vp check"] --> B["vp pack"]
  B --> C["source Knip"]
  C --> D["production Knip"]
  D --> E["one covered unit suite"]
```

Stack: #112 -> #113 -> **#114**.

## Risks

The canonical gate now fails on new unused files or dependencies. That is intentional; explicit API/type tests plus publint and Are The Types Wrong continue to govern intentional public exports.

## Verification

- `vp run verify`: 19 files and 91 tests passed; both Knip graphs were clean; coverage remained above thresholds
- `vp run lint:package`: publint and Are The Types Wrong passed
- `vp run test:compat`: packed SDK passed Node, Chromium, Firefox, WebKit, and Bun consumer checks

## Complexity

Low: the existing checks are reordered into one non-duplicative blocking pipeline.
