### PR TITLE
feat(client): support mutable promise access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,15 @@ Use `makePutioSdkLayer(...)` with `makePutioFetchLayer(...)` or your own `PutioH
 ## Side-By-Side Usage
 
 Both client styles expose the same domain surface. The Promise client also exposes
-`dispose()` for runtime teardown and `files.createUploadFormData(...)` for pure
-FormData construction.
+`setAccessToken(...)` for token rotation, `dispose()` for runtime teardown, and
+`files.createUploadFormData(...)` for pure FormData construction.
 
 ```ts
 promiseClient.files.list(0, { per_page: 20 });
 effectClient.files.list(0, { per_page: 20 });
+
+promiseClient.setAccessToken(refreshedAccessToken);
+promiseClient.setAccessToken(undefined);
 ```
 
 Choose the Promise client when you want standard async functions.
@@ -157,6 +160,7 @@ Effect is the canonical typed surface. The Promise client is an adapter for envi
 - Authenticated endpoints need a token through client config or the Effect layer config
 - Effect client: keeps errors in the Effect error channel with operation-specific typing
 - Promise client: throws tagged SDK error objects such as `PutioOperationError`, `PutioApiError`, and `PutioRateLimitError`
+- Promise client: rotates or clears credentials synchronously with `setAccessToken(...)`; each operation uses the token active when it is invoked
 - Promise client: owns a managed Effect runtime and exposes `dispose()` for explicit teardown
 
 If you create a long-lived Promise client in a script, test harness, or server integration, call `await sdk.dispose()` during teardown.

--- a/scripts/test-compat-node.mts
+++ b/scripts/test-compat-node.mts
@@ -195,6 +195,9 @@ const uploadRequest = await promiseClient.files.createUploadRequest({
   fileName: "node.txt",
 });
 const uploadToken = new URL(uploadRequest.url).searchParams.get("oauth_token");
+if (uploadToken !== "rotated-compat-token") {
+  throw new Error("Promise access-token replacement did not reach the upload request");
+}
 promiseClient.setAccessToken(undefined);
 await promiseClient.dispose();
 
@@ -220,7 +223,7 @@ console.log(
     subtitleLanguage: subtitleLanguage.code,
     uploadMethod: uploadRequest.method,
     uploadBody: uploadRequest.body.constructor.name,
-    uploadToken,
+    uploadTokenUpdated: true,
     utility: toHumanFileSize(1_572_864),
     unknownAppSpecificPasswordError,
   }),

--- a/scripts/test-compat-node.mts
+++ b/scripts/test-compat-node.mts
@@ -189,10 +189,13 @@ const promiseAuthUrl = promiseClient.auth.buildLoginUrl({
   state: "node-smoke",
 });
 const promiseAuthHost = new URL(promiseAuthUrl).host;
+promiseClient.setAccessToken("rotated-compat-token");
 const uploadRequest = await promiseClient.files.createUploadRequest({
   file: new Blob(["hello from node"]),
   fileName: "node.txt",
 });
+const uploadToken = new URL(uploadRequest.url).searchParams.get("oauth_token");
+promiseClient.setAccessToken(undefined);
 await promiseClient.dispose();
 
 const effectClient = createPutioSdkEffectClient();
@@ -217,6 +220,7 @@ console.log(
     subtitleLanguage: subtitleLanguage.code,
     uploadMethod: uploadRequest.method,
     uploadBody: uploadRequest.body.constructor.name,
+    uploadToken,
     utility: toHumanFileSize(1_572_864),
     unknownAppSpecificPasswordError,
   }),

--- a/src/core/client.spec.ts
+++ b/src/core/client.spec.ts
@@ -286,6 +286,46 @@ describe("sdk client factories", () => {
     await beforeFirstRequestClient.dispose();
   });
 
+  it("snapshots caller-owned Promise client URLs", async () => {
+    const requestedUrls: Array<string> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      requestedUrls.push(
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+      );
+      return new Response(JSON.stringify({ status: "OK" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const baseUrl = new URL("https://api.snapshot.test");
+    const uploadBaseUrl = new URL("https://upload.snapshot.test");
+    const webAppUrl = new URL("https://app.snapshot.test");
+    const client = createPutioSdkPromiseClient({
+      accessToken: "token-123",
+      baseUrl,
+      uploadBaseUrl,
+      webAppUrl,
+    });
+
+    baseUrl.hostname = "api.mutated.test";
+    uploadBaseUrl.hostname = "upload.mutated.test";
+    webAppUrl.hostname = "app.mutated.test";
+
+    await expect(client.config.deleteKey("snapshot")).resolves.toEqual({ status: "OK" });
+    const uploadRequest = await client.files.createUploadRequest({
+      file: new Blob(["snapshot"]),
+    });
+
+    expect(requestedUrls).toEqual(["https://api.snapshot.test/v2/config/snapshot"]);
+    expect(uploadRequest.url).toBe(
+      "https://upload.snapshot.test/v2/files/upload?oauth_token=token-123",
+    );
+
+    await client.dispose();
+  });
+
   it("snapshots the Promise access token when an operation is invoked", async () => {
     const authorizations = new Map<string, string | null>();
     let markFirstStarted: (() => void) | undefined;

--- a/src/core/client.spec.ts
+++ b/src/core/client.spec.ts
@@ -299,9 +299,14 @@ describe("sdk client factories", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const baseUrl = new URL("https://api.snapshot.test");
+    const baseUrl = new Proxy(new URL("https://api.snapshot.test"), {
+      get: (target, key) => Reflect.get(target, key, target),
+      getPrototypeOf: () => null,
+      set: (target, key, value) => Reflect.set(target, key, value, target),
+    });
     const uploadBaseUrl = new URL("https://upload.snapshot.test");
     const webAppUrl = new URL("https://app.snapshot.test");
+    expect(baseUrl).not.toBeInstanceOf(URL);
     const client = createPutioSdkPromiseClient({
       accessToken: "token-123",
       baseUrl,
@@ -317,11 +322,17 @@ describe("sdk client factories", () => {
     const uploadRequest = await client.files.createUploadRequest({
       file: new Blob(["snapshot"]),
     });
+    const loginUrl = client.auth.buildLoginUrl({
+      clientId: 1,
+      redirectUri: "https://consumer.test/callback",
+      state: "snapshot",
+    });
 
     expect(requestedUrls).toEqual(["https://api.snapshot.test/v2/config/snapshot"]);
     expect(uploadRequest.url).toBe(
       "https://upload.snapshot.test/v2/files/upload?oauth_token=token-123",
     );
+    expect(new URL(loginUrl).origin).toBe("https://app.snapshot.test");
 
     await client.dispose();
   });

--- a/src/core/client.spec.ts
+++ b/src/core/client.spec.ts
@@ -91,6 +91,7 @@ describe("sdk client factories", () => {
 
     expect(client.dispose).toBeTypeOf("function");
     expect(client.account.appSpecificPasswords.create).toBeTypeOf("function");
+    expect(client.setAccessToken).toBeTypeOf("function");
     expect(client.account.getInfo).toBeTypeOf("function");
     expect(client.account.listSubtitleLanguages).toBeTypeOf("function");
     expect(client.auth.getCode).toBeTypeOf("function");
@@ -110,6 +111,7 @@ describe("sdk client factories", () => {
     expect(promisePaths.filter((path) => !effectPaths.includes(path)).sort()).toEqual([
       "dispose",
       "files.createUploadFormData",
+      "setAccessToken",
     ]);
   });
 
@@ -242,6 +244,99 @@ describe("sdk client factories", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(9);
+  });
+
+  it("updates the Promise access token before and after runtime creation", async () => {
+    const authorizations: Array<string | null> = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      authorizations.push(new Headers(init?.headers).get("authorization"));
+      return new Response(JSON.stringify({ status: "OK" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const initialConfig = { accessToken: "initial-token" };
+    const activeClient = createPutioSdkPromiseClient(initialConfig);
+
+    await expect(activeClient.config.deleteKey("initial")).resolves.toEqual({ status: "OK" });
+    activeClient.setAccessToken("replacement-token");
+    await expect(activeClient.config.deleteKey("replacement")).resolves.toEqual({ status: "OK" });
+    activeClient.setAccessToken(undefined);
+    await expect(activeClient.config.deleteKey("cleared")).rejects.toMatchObject({
+      _tag: "PutioConfigurationError",
+    });
+
+    const beforeFirstRequestClient = createPutioSdkPromiseClient(initialConfig);
+    beforeFirstRequestClient.setAccessToken("before-first-request-token");
+    await expect(beforeFirstRequestClient.config.deleteKey("before-first")).resolves.toEqual({
+      status: "OK",
+    });
+
+    expect(authorizations).toEqual([
+      "Token initial-token",
+      "Token replacement-token",
+      "Token before-first-request-token",
+    ]);
+    expect(initialConfig).toEqual({ accessToken: "initial-token" });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    await activeClient.dispose();
+    await beforeFirstRequestClient.dispose();
+  });
+
+  it("snapshots the Promise access token when an operation is invoked", async () => {
+    const authorizations = new Map<string, string | null>();
+    let markFirstStarted: (() => void) | undefined;
+    let releaseFirst: (() => void) | undefined;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? new URL(input)
+          : input instanceof URL
+            ? input
+            : new URL(input.url);
+      authorizations.set(url.pathname, new Headers(init?.headers).get("authorization"));
+
+      if (url.pathname === "/v2/config/first") {
+        markFirstStarted?.();
+        await firstReleased;
+      }
+
+      return new Response(JSON.stringify({ status: "OK" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createPutioSdkPromiseClient({ accessToken: "first-token" });
+    const firstRequest = client.config.deleteKey("first");
+    client.setAccessToken("second-token");
+
+    await firstStarted;
+    const secondRequest = client.config.deleteKey("second");
+    releaseFirst?.();
+
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([
+      { status: "OK" },
+      { status: "OK" },
+    ]);
+    expect(authorizations).toEqual(
+      new Map([
+        ["/v2/config/first", "Token first-token"],
+        ["/v2/config/second", "Token second-token"],
+      ]),
+    );
+
+    await client.dispose();
   });
 
   it("fails fast after the Promise client runtime is disposed", async () => {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -166,7 +166,13 @@ import {
   type FriendBase,
   type UserSearchResult,
 } from "../domains/friends.js";
-import { makePutioSdkLiveLayer, type PutioSdkConfigShape, type PutioSdkContext } from "./http.js";
+import {
+  makePutioSdkConfig,
+  makePutioSdkLiveLayer,
+  PutioSdkConfig,
+  type PutioSdkConfigShape,
+  type PutioSdkContext,
+} from "./http.js";
 import {
   buildOAuthAppIconUrl,
   buildOAuthAuthorizeUrl,
@@ -300,32 +306,37 @@ import { mapConfigurationError } from "./errors.js";
 
 type PutioSdkPromiseRuntime = ManagedRuntime.ManagedRuntime<PutioSdkContext, never>;
 
-const promiseClientRuntimeCache = new WeakMap<PutioSdkConfigShape, PutioSdkPromiseRuntime>();
-const disposedPromiseClientConfigs = new WeakSet<PutioSdkConfigShape>();
+interface PutioSdkPromiseState {
+  accessToken: string | undefined;
+  readonly runtimeConfig: PutioSdkConfigShape;
+}
 
-const getPromiseClientRuntime = (config: PutioSdkConfigShape): PutioSdkPromiseRuntime => {
-  if (disposedPromiseClientConfigs.has(config)) {
+const promiseClientRuntimeCache = new WeakMap<PutioSdkPromiseState, PutioSdkPromiseRuntime>();
+const disposedPromiseClientStates = new WeakSet<PutioSdkPromiseState>();
+
+const getPromiseClientRuntime = (state: PutioSdkPromiseState): PutioSdkPromiseRuntime => {
+  if (disposedPromiseClientStates.has(state)) {
     throw mapConfigurationError(
       "This Promise client has been disposed and can no longer execute SDK effects",
     );
   }
 
-  const cachedRuntime = promiseClientRuntimeCache.get(config);
+  const cachedRuntime = promiseClientRuntimeCache.get(state);
 
   if (cachedRuntime) {
     return cachedRuntime;
   }
 
-  const runtime = ManagedRuntime.make(makePutioSdkLiveLayer(config));
-  promiseClientRuntimeCache.set(config, runtime);
+  const runtime = ManagedRuntime.make(makePutioSdkLiveLayer(state.runtimeConfig));
+  promiseClientRuntimeCache.set(state, runtime);
   return runtime;
 };
 
-const disposePromiseClientRuntime = async (config: PutioSdkConfigShape): Promise<void> => {
-  disposedPromiseClientConfigs.add(config);
+const disposePromiseClientRuntime = async (state: PutioSdkPromiseState): Promise<void> => {
+  disposedPromiseClientStates.add(state);
 
-  const runtime = promiseClientRuntimeCache.get(config);
-  promiseClientRuntimeCache.delete(config);
+  const runtime = promiseClientRuntimeCache.get(state);
+  promiseClientRuntimeCache.delete(state);
 
   if (!runtime) {
     return;
@@ -349,9 +360,17 @@ const rejectWithSdkFailure = <A, E>(exit: Exit.Exit<A, E>): Promise<A> =>
   });
 
 const provideSdk = async <A, E>(
-  config: PutioSdkConfigShape,
+  state: PutioSdkPromiseState,
   effect: Effect.Effect<A, E, PutioSdkContext>,
-) => rejectWithSdkFailure(await getPromiseClientRuntime(config).runPromiseExit(effect));
+) => {
+  const operationConfig = {
+    ...state.runtimeConfig,
+    accessToken: state.accessToken,
+  };
+  const operation = Effect.provideService(effect, PutioSdkConfig, operationConfig);
+
+  return rejectWithSdkFailure(await getPromiseClientRuntime(state).runPromiseExit(operation));
+};
 
 export const createPutioSdkEffectClient = () => ({
   account: {
@@ -593,7 +612,11 @@ export const makePutioSdkLiveClientLayer = (config: PutioSdkConfigShape) =>
   Layer.mergeAll(makePutioSdkEffectClientLayer(), makePutioSdkLiveLayer(config));
 
 export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape = {}) => {
-  const config = { ...initialConfig };
+  const runtimeConfig = makePutioSdkConfig(initialConfig);
+  const config: PutioSdkPromiseState = {
+    accessToken: runtimeConfig.accessToken,
+    runtimeConfig,
+  };
 
   function getInfo(query: {
     readonly download_token: 1;
@@ -662,6 +685,9 @@ export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape =
 
   return {
     dispose: () => disposePromiseClientRuntime(config),
+    setAccessToken: (accessToken: string | undefined): void => {
+      config.accessToken = accessToken;
+    },
     account: {
       appSpecificPasswords: {
         create: (input: CreateAppSpecificPasswordInput): Promise<CreateAppSpecificPasswordResult> =>

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -372,6 +372,9 @@ const provideSdk = async <A, E>(
   return rejectWithSdkFailure(await getPromiseClientRuntime(state).runPromiseExit(operation));
 };
 
+const snapshotUrl = (value: string | URL | undefined): string | URL | undefined =>
+  value instanceof URL ? new URL(value.href) : value;
+
 export const createPutioSdkEffectClient = () => ({
   account: {
     appSpecificPasswords: {
@@ -612,7 +615,12 @@ export const makePutioSdkLiveClientLayer = (config: PutioSdkConfigShape) =>
   Layer.mergeAll(makePutioSdkEffectClientLayer(), makePutioSdkLiveLayer(config));
 
 export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape = {}) => {
-  const runtimeConfig = makePutioSdkConfig(initialConfig);
+  const runtimeConfig = makePutioSdkConfig({
+    ...initialConfig,
+    baseUrl: snapshotUrl(initialConfig.baseUrl),
+    uploadBaseUrl: snapshotUrl(initialConfig.uploadBaseUrl),
+    webAppUrl: snapshotUrl(initialConfig.webAppUrl),
+  });
   const config: PutioSdkPromiseState = {
     accessToken: runtimeConfig.accessToken,
     runtimeConfig,

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -305,10 +305,11 @@ import {
 import { mapConfigurationError } from "./errors.js";
 
 type PutioSdkPromiseRuntime = ManagedRuntime.ManagedRuntime<PutioSdkContext, never>;
+type PutioSdkPromiseRuntimeConfig = Omit<PutioSdkConfigShape, "accessToken">;
 
 interface PutioSdkPromiseState {
   accessToken: string | undefined;
-  readonly runtimeConfig: PutioSdkConfigShape;
+  readonly runtimeConfig: PutioSdkPromiseRuntimeConfig;
 }
 
 const promiseClientRuntimeCache = new WeakMap<PutioSdkPromiseState, PutioSdkPromiseRuntime>();
@@ -373,7 +374,7 @@ const provideSdk = async <A, E>(
 };
 
 const snapshotUrl = (value: string | URL | undefined): string | URL | undefined =>
-  value instanceof URL ? new URL(value.href) : value;
+  typeof value === "string" || value === undefined ? value : new URL(value.href);
 
 export const createPutioSdkEffectClient = () => ({
   account: {
@@ -615,14 +616,19 @@ export const makePutioSdkLiveClientLayer = (config: PutioSdkConfigShape) =>
   Layer.mergeAll(makePutioSdkEffectClientLayer(), makePutioSdkLiveLayer(config));
 
 export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape = {}) => {
-  const runtimeConfig = makePutioSdkConfig({
+  const normalizedConfig = makePutioSdkConfig({
     ...initialConfig,
     baseUrl: snapshotUrl(initialConfig.baseUrl),
     uploadBaseUrl: snapshotUrl(initialConfig.uploadBaseUrl),
     webAppUrl: snapshotUrl(initialConfig.webAppUrl),
   });
+  const runtimeConfig: PutioSdkPromiseRuntimeConfig = {
+    baseUrl: normalizedConfig.baseUrl,
+    uploadBaseUrl: normalizedConfig.uploadBaseUrl,
+    webAppUrl: normalizedConfig.webAppUrl,
+  };
   const config: PutioSdkPromiseState = {
-    accessToken: runtimeConfig.accessToken,
+    accessToken: initialConfig.accessToken,
     runtimeConfig,
   };
 
@@ -717,7 +723,11 @@ export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape =
         provideSdk(config, saveAccountSettings(payload)),
     },
     auth: {
-      buildLoginUrl: buildAuthLoginUrl,
+      buildLoginUrl: (options: Parameters<typeof buildAuthLoginUrl>[0]) =>
+        buildAuthLoginUrl({
+          ...options,
+          webAppUrl: options.webAppUrl ?? config.runtimeConfig.webAppUrl,
+        }),
       checkCodeMatch: (code: string) => provideSdk(config, checkCodeMatch(code)),
       clients: (): Promise<ReadonlyArray<OAuthAppSession>> => provideSdk(config, clients()),
       exists: (key: "mail" | "username", value: string) => provideSdk(config, exists(key, value)),


### PR DESCRIPTION
Part of #108.

## Summary

Add `setAccessToken(string | undefined)` to the Promise client without recreating its managed Effect runtime.

## Changed

- keep immutable URL configuration separate from client-private token state
- snapshot the current token synchronously when each Promise operation is invoked
- provide that snapshot to the operation while reusing the existing managed runtime
- cover initial, replacement, pre-runtime replacement, clearing, disposal, and concurrent in-flight behavior
- exercise the method through the packed external Node consumer

## Review aids

```mermaid
flowchart LR
  A["setAccessToken(next)"] --> B["private token state"]
  C["Promise operation invoked"] --> D["snapshot token + immutable URLs"]
  B --> D
  D --> E["Effect.provideService(PutioSdkConfig)"]
  E --> F["same managed runtime"]
```

The concurrency test invokes operation A with token 1, changes the client to token 2 while A is still in flight, then proves A used token 1 and operation B used token 2.

Stack: **#116** -> #117.

## Risks

The mutable value is confined to the Promise-client closure. Caller-owned configuration is copied, URLs stay fixed, tokens are neither persisted nor logged, and disposal still permanently rejects later operations.

## Verification

- focused client suite: 10 tests passed
- canonical verification: 19 files and 93 tests passed with coverage above thresholds
- package lint: publint and Are The Types Wrong passed
- packed compatibility: Node, Chromium, Firefox, WebKit, and Bun passed
- external Node fixture observed `rotated-compat-token` in the generated upload URL

## Complexity

Medium: one private state boundary and one per-operation service override; the public API addition is a single synchronous setter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mutable access tokens to the Promise client so you can rotate or clear tokens at runtime without recreating the client, supporting Epic-108 (Promise token lifecycle). Each request snapshots the token at call time, and the client snapshots and normalizes URL config at creation to keep auth and endpoints stable.

- **New Features**
  - Added `setAccessToken(accessToken | undefined)` to the Promise client.
  - Each operation uses the token active when invoked; concurrent requests stay isolated.
  - Runtime keyed by client state; `auth.buildLoginUrl` falls back to the snapshot `webAppUrl`. Tests cover pre/post-runtime rotation, URL snapshots (including mutated proxies), and concurrent behavior; Node smoke asserts rotated token in upload request; README documents rotation/clearing.

- **Bug Fixes**
  - Hardened config snapshotting by normalizing config and cloning `URL` values; runtime is isolated from token state so later mutations cannot affect requests.

<sup>Written for commit d613aa0354564dff2f93597d4420a597a1804956. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

