### PR TITLE
feat(account): add app-specific passwords

### DIFF
--- a/scripts/test-compat-node.mts
+++ b/scripts/test-compat-node.mts
@@ -58,6 +58,7 @@ const main = async () => {
 import {
   createPutioSdkEffectClient,
   createPutioSdkPromiseClient,
+  type CreateAppSpecificPasswordError,
   type PutioSdkPromiseClient,
 } from "@putdotio/sdk";
 import { toHumanFileSize } from "@putdotio/sdk/utilities";
@@ -82,6 +83,16 @@ const appSpecificPassword: AppSpecificPasswords[number] = {
   last_used_at: null,
   note: "Laptop",
 };
+type CreateAppSpecificPasswordOperationError = Extract<
+  CreateAppSpecificPasswordError,
+  { readonly _tag: "PutioOperationError" }
+>;
+type CreateAppSpecificPasswordErrorType =
+  CreateAppSpecificPasswordOperationError["contract"]["errorType"];
+const knownAppSpecificPasswordError: CreateAppSpecificPasswordErrorType =
+  "TOO_MANY_APP_SPECIFIC_PASSWORDS";
+// @ts-expect-error unknown app-specific-password error literals are not part of the public contract
+const unknownAppSpecificPasswordError: CreateAppSpecificPasswordErrorType = "UNKNOWN_ERROR";
 const promiseAuthUrl = promiseClient.auth.buildLoginUrl({
   clientId: "external-node",
   redirectUri: "https://example.com/callback",
@@ -110,12 +121,14 @@ const effectAuthHost = await Effect.runPromise(
 console.log(
   JSON.stringify({
     effectAuthHost,
+    knownAppSpecificPasswordError,
     appSpecificPasswordNote: appSpecificPassword.note,
     promiseAuthHost,
     subtitleLanguage: subtitleLanguage.code,
     uploadMethod: uploadRequest.method,
     uploadBody: uploadRequest.body.constructor.name,
     utility: toHumanFileSize(1_572_864),
+    unknownAppSpecificPasswordError,
   }),
 );
 `,

--- a/scripts/test-compat-node.mts
+++ b/scripts/test-compat-node.mts
@@ -72,6 +72,16 @@ const subtitleLanguage: SubtitleLanguages[number] = {
   code: "eng",
   name: "English",
 };
+type AppSpecificPasswords = Awaited<
+  ReturnType<PutioSdkPromiseClient["account"]["appSpecificPasswords"]["list"]>
+>;
+const appSpecificPassword: AppSpecificPasswords[number] = {
+  created_at: "2026-08-01T10:00:00Z",
+  id: 42,
+  ip_address: "203.0.113.XXX",
+  last_used_at: null,
+  note: "Laptop",
+};
 const promiseAuthUrl = promiseClient.auth.buildLoginUrl({
   clientId: "external-node",
   redirectUri: "https://example.com/callback",
@@ -100,6 +110,7 @@ const effectAuthHost = await Effect.runPromise(
 console.log(
   JSON.stringify({
     effectAuthHost,
+    appSpecificPasswordNote: appSpecificPassword.note,
     promiseAuthHost,
     subtitleLanguage: subtitleLanguage.code,
     uploadMethod: uploadRequest.method,

--- a/src/core/client.spec.ts
+++ b/src/core/client.spec.ts
@@ -36,6 +36,7 @@ describe("sdk client factories", () => {
   it("creates the Effect-first SDK client surface", () => {
     const client = createPutioSdkEffectClient();
 
+    expect(client.account.appSpecificPasswords.create).toBeTypeOf("function");
     expect(client.account.getInfo).toBeTypeOf("function");
     expect(client.account.listSubtitleLanguages).toBeTypeOf("function");
     expect(client.auth.getCode).toBeTypeOf("function");
@@ -89,6 +90,7 @@ describe("sdk client factories", () => {
     const client = createPutioSdkPromiseClient({ accessToken: "token-123" });
 
     expect(client.dispose).toBeTypeOf("function");
+    expect(client.account.appSpecificPasswords.create).toBeTypeOf("function");
     expect(client.account.getInfo).toBeTypeOf("function");
     expect(client.account.listSubtitleLanguages).toBeTypeOf("function");
     expect(client.auth.getCode).toBeTypeOf("function");

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -19,6 +19,15 @@ import {
   type AccountClearOptions,
 } from "../domains/account.js";
 import {
+  createAppSpecificPassword,
+  deleteAllAppSpecificPasswords,
+  deleteAppSpecificPassword,
+  listAppSpecificPasswords,
+  type AppSpecificPassword,
+  type CreateAppSpecificPasswordInput,
+  type CreateAppSpecificPasswordResult,
+} from "../domains/app-specific-passwords.js";
+import {
   buildAuthLoginUrl,
   checkCodeMatch,
   clients,
@@ -346,6 +355,12 @@ const provideSdk = async <A, E>(
 
 export const createPutioSdkEffectClient = () => ({
   account: {
+    appSpecificPasswords: {
+      create: createAppSpecificPassword,
+      delete: deleteAppSpecificPassword,
+      deleteAll: deleteAllAppSpecificPasswords,
+      list: listAppSpecificPasswords,
+    },
     clear: clearAccount,
     destroy: destroyAccount,
     getInfo: getAccountInfo,
@@ -647,6 +662,14 @@ export const createPutioSdkPromiseClient = (initialConfig: PutioSdkConfigShape =
   return {
     dispose: () => disposePromiseClientRuntime(config),
     account: {
+      appSpecificPasswords: {
+        create: (input: CreateAppSpecificPasswordInput): Promise<CreateAppSpecificPasswordResult> =>
+          provideSdk(config, createAppSpecificPassword(input)),
+        delete: (id: number): Promise<void> => provideSdk(config, deleteAppSpecificPassword(id)),
+        deleteAll: (): Promise<void> => provideSdk(config, deleteAllAppSpecificPasswords()),
+        list: (): Promise<ReadonlyArray<AppSpecificPassword>> =>
+          provideSdk(config, listAppSpecificPasswords()),
+      },
       clear: (options: AccountClearOptions) => provideSdk(config, clearAccount(options)),
       destroy: (currentPassword: string) => provideSdk(config, destroyAccount(currentPassword)),
       getInfo,

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -16,7 +16,9 @@ export type PutioErrorEnvelope = Schema.Schema.Type<typeof PutioErrorEnvelopeSch
 export interface PutioKnownErrorContract<
   TType extends string = string,
   TStatus extends number = number,
+  TBody extends PutioErrorEnvelope = PutioErrorEnvelope,
 > {
+  readonly bodySchema?: Schema.Schema<TBody> | undefined;
   readonly errorType?: TType | undefined;
   readonly statusCode?: TStatus | undefined;
 }
@@ -27,18 +29,24 @@ type ContractErrorType<TContract extends PutioKnownErrorContract> =
 type ContractStatusCode<TContract extends PutioKnownErrorContract> =
   TContract extends PutioKnownErrorContract<string, infer TStatus> ? TStatus : never;
 
-export type PutioTypedErrorEnvelope<TContract extends PutioKnownErrorContract> = Omit<
-  PutioErrorEnvelope,
-  "error_message" | "error_type" | "status_code"
-> & {
-  readonly error_message?: string;
-  readonly error_type?: [ContractErrorType<TContract>] extends [never]
-    ? string
-    : ContractErrorType<TContract>;
-  readonly status_code?: [ContractStatusCode<TContract>] extends [never]
-    ? number
-    : ContractStatusCode<TContract>;
-};
+type ContractBody<TContract extends PutioKnownErrorContract> = TContract extends {
+  readonly bodySchema: Schema.Schema<infer TBody extends PutioErrorEnvelope>;
+}
+  ? TBody
+  : PutioErrorEnvelope;
+
+export type PutioTypedErrorEnvelope<TContract extends PutioKnownErrorContract> =
+  TContract extends PutioKnownErrorContract
+    ? Omit<ContractBody<TContract>, "error_message" | "error_type" | "status_code"> & {
+        readonly error_message?: string;
+        readonly error_type?: [ContractErrorType<TContract>] extends [never]
+          ? string
+          : ContractErrorType<TContract>;
+        readonly status_code?: [ContractStatusCode<TContract>] extends [never]
+          ? number
+          : ContractStatusCode<TContract>;
+      }
+    : never;
 
 export interface PutioOperationErrorSpec<
   TDomain extends string = string,
@@ -90,6 +98,10 @@ const isKnownContractMatch = <TContract extends PutioKnownErrorContract>(
   contract: TContract,
   error: PutioApiError | PutioAuthError,
 ): contract is Extract<TContract, PutioKnownOperationErrorContract> => {
+  if (contract.bodySchema !== undefined && !Schema.is(contract.bodySchema)(error.body)) {
+    return false;
+  }
+
   if (contract.errorType !== undefined) {
     if (error.body.error_type !== contract.errorType) {
       return false;

--- a/src/domains/app-specific-passwords.spec.ts
+++ b/src/domains/app-specific-passwords.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { PutioOperationError, PutioValidationError } from "../core/errors.js";
+import { PutioAuthError, PutioOperationError, PutioValidationError } from "../core/errors.js";
 import {
   expectFailure,
   getFormBody,
@@ -83,6 +83,22 @@ describe("app-specific password boundaries", () => {
     ]);
   });
 
+  it("rejects malformed masked IP addresses from the API", async () => {
+    const failure = expectFailure(
+      await runSdkExit(
+        listAppSpecificPasswords(),
+        () =>
+          jsonResponse({
+            passwords: [{ ...appSpecificPassword, ip_address: "not-an-ip.XXX" }],
+            status: "OK",
+          }),
+        { accessToken: "token-123" },
+      ),
+    );
+
+    expect(failure).toBeInstanceOf(PutioValidationError);
+  });
+
   it("rejects invalid create and delete inputs before transport", async () => {
     let requestCount = 0;
     const handler = () => {
@@ -144,6 +160,38 @@ describe("app-specific password boundaries", () => {
       },
       status: 403,
     });
+
+    if (
+      !(failure instanceof PutioOperationError) ||
+      failure.body.error_type !== "TOO_MANY_APP_SPECIFIC_PASSWORDS"
+    ) {
+      throw new Error("Expected a typed app-specific password quota failure.");
+    }
+
+    const limit: number = failure.body.extra.limit;
+    expect(limit).toBe(10);
+  });
+
+  it("does not classify malformed quota metadata as a typed operation error", async () => {
+    const failure = expectFailure(
+      await runSdkExit(
+        createAppSpecificPassword({ note: "Laptop" }),
+        () =>
+          jsonResponse(
+            {
+              error_message: "Quota reached.",
+              error_type: "TOO_MANY_APP_SPECIFIC_PASSWORDS",
+              extra: { limit: "10" },
+              status_code: 403,
+            },
+            { status: 403 },
+          ),
+        { accessToken: "token-123" },
+      ),
+    );
+
+    expect(failure).toBeInstanceOf(PutioAuthError);
+    expect(failure).not.toBeInstanceOf(PutioOperationError);
   });
 
   it("deletes one or all app-specific passwords", async () => {

--- a/src/domains/app-specific-passwords.spec.ts
+++ b/src/domains/app-specific-passwords.spec.ts
@@ -83,21 +83,41 @@ describe("app-specific password boundaries", () => {
     ]);
   });
 
-  it("rejects malformed masked IP addresses from the API", async () => {
-    const failure = expectFailure(
-      await runSdkExit(
-        listAppSpecificPasswords(),
-        () =>
-          jsonResponse({
-            passwords: [{ ...appSpecificPassword, ip_address: "not-an-ip.XXX" }],
-            status: "OK",
-          }),
-        { accessToken: "token-123" },
-      ),
-    );
+  it.each(["127.0.0.XXX", "2001::db8:X", "1:2:3:4:5:6:7:X"])(
+    "accepts masked IP address %s from the API",
+    async (ipAddress) => {
+      await expect(
+        runSdkEffect(
+          listAppSpecificPasswords(),
+          () =>
+            jsonResponse({
+              passwords: [{ ...appSpecificPassword, ip_address: ipAddress }],
+              status: "OK",
+            }),
+          { accessToken: "token-123" },
+        ),
+      ).resolves.toEqual([{ ...appSpecificPassword, ip_address: ipAddress }]);
+    },
+  );
 
-    expect(failure).toBeInstanceOf(PutioValidationError);
-  });
+  it.each(["not-an-ip.XXX", "1:2:3:4:5:6:7::X", "2001:::X"])(
+    "rejects malformed masked IP address %s from the API",
+    async (ipAddress) => {
+      const failure = expectFailure(
+        await runSdkExit(
+          listAppSpecificPasswords(),
+          () =>
+            jsonResponse({
+              passwords: [{ ...appSpecificPassword, ip_address: ipAddress }],
+              status: "OK",
+            }),
+          { accessToken: "token-123" },
+        ),
+      );
+
+      expect(failure).toBeInstanceOf(PutioValidationError);
+    },
+  );
 
   it("rejects invalid create and delete inputs before transport", async () => {
     let requestCount = 0;

--- a/src/domains/app-specific-passwords.spec.ts
+++ b/src/domains/app-specific-passwords.spec.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { PutioOperationError, PutioValidationError } from "../core/errors.js";
+import {
+  expectFailure,
+  getFormBody,
+  jsonResponse,
+  runSdkEffect,
+  runSdkExit,
+} from "../../test/support/sdk-test.js";
+import {
+  createAppSpecificPassword,
+  deleteAllAppSpecificPasswords,
+  deleteAppSpecificPassword,
+  listAppSpecificPasswords,
+} from "./app-specific-passwords.js";
+
+const appSpecificPassword = {
+  created_at: "2026-08-01T10:00:00Z",
+  id: 42,
+  ip_address: null,
+  last_used_at: null,
+  note: "Laptop",
+};
+
+describe("app-specific password boundaries", () => {
+  it("creates a password once and sends the trimmed note", async () => {
+    expect(
+      await runSdkEffect(
+        createAppSpecificPassword({ note: "  Laptop  " }),
+        (request) => {
+          expect(request.method).toBe("POST");
+          expect(request.url).toBe("https://api.put.io/v2/app_specific_password/create");
+          expect(getFormBody(request).get("note")).toBe("Laptop");
+
+          return jsonResponse({
+            ...appSpecificPassword,
+            password: "one-time-password",
+            status: "OK",
+          });
+        },
+        { accessToken: "token-123" },
+      ),
+    ).toEqual({
+      ...appSpecificPassword,
+      password: "one-time-password",
+    });
+  });
+
+  it("lists metadata without requiring a password or last-used timestamp", async () => {
+    expect(
+      await runSdkEffect(
+        listAppSpecificPasswords(),
+        (request) => {
+          expect(request.method).toBe("GET");
+          expect(request.url).toBe("https://api.put.io/v2/app_specific_password/list");
+
+          return jsonResponse({
+            passwords: [
+              appSpecificPassword,
+              {
+                ...appSpecificPassword,
+                id: 43,
+                ip_address: "2001:db8::X",
+                last_used_at: "2026-08-01T11:00:00Z",
+                note: "Media server",
+              },
+            ],
+            status: "OK",
+          });
+        },
+        { accessToken: "token-123" },
+      ),
+    ).toEqual([
+      appSpecificPassword,
+      {
+        ...appSpecificPassword,
+        id: 43,
+        ip_address: "2001:db8::X",
+        last_used_at: "2026-08-01T11:00:00Z",
+        note: "Media server",
+      },
+    ]);
+  });
+
+  it("rejects invalid create and delete inputs before transport", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+
+    const missingNote = expectFailure(
+      await runSdkExit(createAppSpecificPassword({ note: "   " }), handler, {
+        accessToken: "token-123",
+      }),
+    );
+    const longNote = expectFailure(
+      await runSdkExit(createAppSpecificPassword({ note: "x".repeat(256) }), handler, {
+        accessToken: "token-123",
+      }),
+    );
+    const invalidId = expectFailure(
+      await runSdkExit(deleteAppSpecificPassword(0), handler, {
+        accessToken: "token-123",
+      }),
+    );
+
+    expect(missingNote).toBeInstanceOf(PutioValidationError);
+    expect(longNote).toBeInstanceOf(PutioValidationError);
+    expect(invalidId).toBeInstanceOf(PutioValidationError);
+    expect(requestCount).toBe(0);
+  });
+
+  it("types create failures and preserves structured limits", async () => {
+    const failure = expectFailure(
+      await runSdkExit(
+        createAppSpecificPassword({ note: "Laptop" }),
+        () =>
+          jsonResponse(
+            {
+              error_message: "Maximum 10 app-specific passwords are allowed.",
+              error_type: "TOO_MANY_APP_SPECIFIC_PASSWORDS",
+              extra: { limit: 10 },
+              status_code: 403,
+            },
+            { status: 403 },
+          ),
+        { accessToken: "token-123" },
+      ),
+    );
+
+    expect(failure).toBeInstanceOf(PutioOperationError);
+    expect(failure).toMatchObject({
+      body: {
+        error_type: "TOO_MANY_APP_SPECIFIC_PASSWORDS",
+        extra: { limit: 10 },
+      },
+      domain: "account",
+      operation: "appSpecificPasswords.create",
+      reason: {
+        errorType: "TOO_MANY_APP_SPECIFIC_PASSWORDS",
+        kind: "error_type",
+      },
+      status: 403,
+    });
+  });
+
+  it("deletes one or all app-specific passwords", async () => {
+    await expect(
+      runSdkEffect(
+        deleteAppSpecificPassword(42),
+        (request) => {
+          expect(request.method).toBe("POST");
+          expect(request.url).toBe("https://api.put.io/v2/app_specific_password/42/delete");
+          return jsonResponse({ status: "OK" });
+        },
+        { accessToken: "token-123" },
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      runSdkEffect(
+        deleteAllAppSpecificPasswords(),
+        (request) => {
+          expect(request.method).toBe("POST");
+          expect(request.url).toBe("https://api.put.io/v2/app_specific_password/delete_all");
+          return jsonResponse({ status: "OK" });
+        },
+        { accessToken: "token-123" },
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/domains/app-specific-passwords.ts
+++ b/src/domains/app-specific-passwords.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect";
 
 import {
+  PutioErrorEnvelopeSchema,
   definePutioOperationErrorSpec,
   mapDecodeErrorToValidationError,
   withOperationErrors,
@@ -20,7 +21,11 @@ const AppSpecificPasswordNoteSchema = Schema.Trim.check(
   Schema.isMinLength(1),
   Schema.isMaxLength(255),
 );
-const MaskedIpAddressSchema = Schema.String.check(Schema.isPattern(/(?:\.XXX|::X)$/));
+const MaskedIpAddressSchema = Schema.String.check(
+  Schema.isPattern(
+    /^(?:(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}XXX|(?:(?:[\dA-Fa-f]{1,4}:){0,7}|:):X)$/,
+  ),
+);
 
 export const AppSpecificPasswordSchema = Schema.Struct({
   created_at: Schema.String,
@@ -62,13 +67,25 @@ const RestrictedAppSpecificPasswordError: {
   statusCode: 401,
 };
 
+const TooManyAppSpecificPasswordsErrorBodySchema = PutioErrorEnvelopeSchema.pipe(
+  Schema.fieldsAssign({
+    extra: Schema.Struct({
+      limit: Schema.Int,
+    }),
+  }),
+);
+
 export const CreateAppSpecificPasswordErrorSpec = definePutioOperationErrorSpec({
   domain: "account",
   operation: "appSpecificPasswords.create",
   knownErrors: [
     { errorType: "NOTE_REQUIRED", statusCode: 400 as const },
     { errorType: "NOTE_TOO_LONG", statusCode: 400 as const },
-    { errorType: "TOO_MANY_APP_SPECIFIC_PASSWORDS", statusCode: 403 as const },
+    {
+      bodySchema: TooManyAppSpecificPasswordsErrorBodySchema,
+      errorType: "TOO_MANY_APP_SPECIFIC_PASSWORDS",
+      statusCode: 403 as const,
+    },
     RestrictedAppSpecificPasswordError,
   ],
 });

--- a/src/domains/app-specific-passwords.ts
+++ b/src/domains/app-specific-passwords.ts
@@ -54,9 +54,12 @@ export type CreateAppSpecificPasswordResult = AppSpecificPassword & {
   readonly password: string;
 };
 
-const RestrictedAppSpecificPasswordError = {
+const RestrictedAppSpecificPasswordError: {
+  readonly errorType: "invalid_scope";
+  readonly statusCode: 401;
+} = {
   errorType: "invalid_scope",
-  statusCode: 401 as const,
+  statusCode: 401,
 };
 
 export const CreateAppSpecificPasswordErrorSpec = definePutioOperationErrorSpec({

--- a/src/domains/app-specific-passwords.ts
+++ b/src/domains/app-specific-passwords.ts
@@ -21,9 +21,33 @@ const AppSpecificPasswordNoteSchema = Schema.Trim.check(
   Schema.isMinLength(1),
   Schema.isMaxLength(255),
 );
+const MaskedIpv4AddressPattern = /^(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}XXX$/;
+const Ipv6HextetPattern = /^[\dA-Fa-f]{1,4}$/;
+
+const isMaskedIpv6Address = (value: string): boolean => {
+  const compressedParts = value.split("::");
+
+  if (compressedParts.length > 2) {
+    return false;
+  }
+
+  const hextets = compressedParts.flatMap((part) => (part === "" ? [] : part.split(":")));
+
+  if (
+    hextets.at(-1) !== "X" ||
+    !hextets.slice(0, -1).every((part) => Ipv6HextetPattern.test(part))
+  ) {
+    return false;
+  }
+
+  return compressedParts.length === 2 ? hextets.length < 8 : hextets.length === 8;
+};
+
 const MaskedIpAddressSchema = Schema.String.check(
-  Schema.isPattern(
-    /^(?:(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}XXX|(?:(?:[\dA-Fa-f]{1,4}:){0,7}|:):X)$/,
+  Schema.makeFilter((value) =>
+    MaskedIpv4AddressPattern.test(value) || isMaskedIpv6Address(value)
+      ? undefined
+      : "Expected a masked IP address",
   ),
 );
 

--- a/src/domains/app-specific-passwords.ts
+++ b/src/domains/app-specific-passwords.ts
@@ -1,0 +1,160 @@
+import { Effect, Schema } from "effect";
+
+import {
+  definePutioOperationErrorSpec,
+  mapDecodeErrorToValidationError,
+  withOperationErrors,
+  type PutioOperationFailure,
+} from "../core/errors.js";
+import {
+  OkResponseSchema,
+  encodePathSegment,
+  requestJson,
+  selectJsonField,
+  selectJsonFields,
+  type PutioSdkContext,
+} from "../core/http.js";
+
+const AppSpecificPasswordIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
+const AppSpecificPasswordNoteSchema = Schema.Trim.check(
+  Schema.isMinLength(1),
+  Schema.isMaxLength(255),
+);
+const MaskedIpAddressSchema = Schema.String.check(Schema.isPattern(/(?:\.XXX|::X)$/));
+
+export const AppSpecificPasswordSchema = Schema.Struct({
+  created_at: Schema.String,
+  id: AppSpecificPasswordIdSchema,
+  ip_address: Schema.NullOr(MaskedIpAddressSchema),
+  last_used_at: Schema.NullOr(Schema.String),
+  note: Schema.String,
+});
+
+export const CreateAppSpecificPasswordInputSchema = Schema.Struct({
+  note: AppSpecificPasswordNoteSchema,
+});
+
+const CreateAppSpecificPasswordEnvelopeSchema = AppSpecificPasswordSchema.pipe(
+  Schema.fieldsAssign({
+    password: Schema.String,
+    status: Schema.Literal("OK"),
+  }),
+);
+
+const ListAppSpecificPasswordsEnvelopeSchema = Schema.Struct({
+  passwords: Schema.Array(AppSpecificPasswordSchema),
+  status: Schema.Literal("OK"),
+});
+
+export type AppSpecificPassword = Schema.Schema.Type<typeof AppSpecificPasswordSchema>;
+export type CreateAppSpecificPasswordInput = Schema.Schema.Type<
+  typeof CreateAppSpecificPasswordInputSchema
+>;
+export type CreateAppSpecificPasswordResult = AppSpecificPassword & {
+  readonly password: string;
+};
+
+const RestrictedAppSpecificPasswordError = {
+  errorType: "invalid_scope",
+  statusCode: 401 as const,
+};
+
+export const CreateAppSpecificPasswordErrorSpec = definePutioOperationErrorSpec({
+  domain: "account",
+  operation: "appSpecificPasswords.create",
+  knownErrors: [
+    { errorType: "NOTE_REQUIRED", statusCode: 400 as const },
+    { errorType: "NOTE_TOO_LONG", statusCode: 400 as const },
+    { errorType: "TOO_MANY_APP_SPECIFIC_PASSWORDS", statusCode: 403 as const },
+    RestrictedAppSpecificPasswordError,
+  ],
+});
+
+export const ListAppSpecificPasswordsErrorSpec = definePutioOperationErrorSpec({
+  domain: "account",
+  operation: "appSpecificPasswords.list",
+  knownErrors: [RestrictedAppSpecificPasswordError],
+});
+
+export const DeleteAppSpecificPasswordErrorSpec = definePutioOperationErrorSpec({
+  domain: "account",
+  operation: "appSpecificPasswords.delete",
+  knownErrors: [RestrictedAppSpecificPasswordError],
+});
+
+export const DeleteAllAppSpecificPasswordsErrorSpec = definePutioOperationErrorSpec({
+  domain: "account",
+  operation: "appSpecificPasswords.deleteAll",
+  knownErrors: [RestrictedAppSpecificPasswordError],
+});
+
+export type CreateAppSpecificPasswordError = PutioOperationFailure<
+  typeof CreateAppSpecificPasswordErrorSpec
+>;
+export type ListAppSpecificPasswordsError = PutioOperationFailure<
+  typeof ListAppSpecificPasswordsErrorSpec
+>;
+export type DeleteAppSpecificPasswordError = PutioOperationFailure<
+  typeof DeleteAppSpecificPasswordErrorSpec
+>;
+export type DeleteAllAppSpecificPasswordsError = PutioOperationFailure<
+  typeof DeleteAllAppSpecificPasswordsErrorSpec
+>;
+
+export const createAppSpecificPassword = (
+  input: CreateAppSpecificPasswordInput,
+): Effect.Effect<
+  CreateAppSpecificPasswordResult,
+  CreateAppSpecificPasswordError,
+  PutioSdkContext
+> =>
+  Schema.decodeUnknownEffect(CreateAppSpecificPasswordInputSchema)(input).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(CreateAppSpecificPasswordEnvelopeSchema, {
+        body: {
+          type: "form",
+          value: decodedInput,
+        },
+        method: "POST",
+        path: "/v2/app_specific_password/create",
+      }),
+    ),
+    selectJsonFields("created_at", "id", "ip_address", "last_used_at", "note", "password"),
+    withOperationErrors(CreateAppSpecificPasswordErrorSpec),
+  );
+
+export const listAppSpecificPasswords = (): Effect.Effect<
+  ReadonlyArray<AppSpecificPassword>,
+  ListAppSpecificPasswordsError,
+  PutioSdkContext
+> =>
+  requestJson(ListAppSpecificPasswordsEnvelopeSchema, {
+    method: "GET",
+    path: "/v2/app_specific_password/list",
+  }).pipe(selectJsonField("passwords"), withOperationErrors(ListAppSpecificPasswordsErrorSpec));
+
+export const deleteAppSpecificPassword = (
+  id: number,
+): Effect.Effect<void, DeleteAppSpecificPasswordError, PutioSdkContext> =>
+  Schema.decodeUnknownEffect(AppSpecificPasswordIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/app_specific_password/${encodePathSegment(decodedId)}/delete`,
+      }),
+    ),
+    Effect.asVoid,
+    withOperationErrors(DeleteAppSpecificPasswordErrorSpec),
+  );
+
+export const deleteAllAppSpecificPasswords = (): Effect.Effect<
+  void,
+  DeleteAllAppSpecificPasswordsError,
+  PutioSdkContext
+> =>
+  requestJson(OkResponseSchema, {
+    method: "POST",
+    path: "/v2/app_specific_password/delete_all",
+  }).pipe(Effect.asVoid, withOperationErrors(DeleteAllAppSpecificPasswordsErrorSpec));

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export * from "./core/defaults.js";
 export * from "./core/errors.js";
 export * from "./core/http.js";
 export * from "./domains/account.js";
+export * from "./domains/app-specific-passwords.js";
 export * from "./domains/auth.js";
 export * from "./domains/config.js";
 export * from "./domains/download-links.js";


### PR DESCRIPTION
Part of #108. This is 3/4 in stack #111 and depends on #110.

## Summary

Expose the complete app-specific-password lifecycle under `account.appSpecificPasswords` on both Effect and Promise clients.

## Changed

- add `create`, `list`, `delete`, and `deleteAll`
- expose the one-time plaintext password only from `create`
- model list metadata with nullable `last_used_at` and null or masked `ip_address`
- trim and validate create notes and validate delete IDs before transport
- type known create failures, including structured `extra.limit`
- export schemas and types through the public package entrypoint
- compile the new public surface from an installed package tarball

## Review aids

| Operation | Method and route | Result |
| --- | --- | --- |
| create | POST `/v2/app_specific_password/create` | metadata plus one-time `password` |
| list | GET `/v2/app_specific_password/list` | metadata only |
| delete | POST `/v2/app_specific_password/:id/delete` | void |
| delete all | POST `/v2/app_specific_password/delete_all` | void |

Create validation mirrors the public boundary: notes are trimmed, must contain 1-255 characters, and invalid input never reaches transport.

## Risks

These methods manage authentication credentials and deletion is externally mutating when a consumer invokes it. The SDK does not call them implicitly, persist or log plaintext passwords, or expose a password from list responses.

## Verification

- focused boundary/client suites: 13 tests passed
- canonical verification: 20 files and 96 tests passed with coverage above thresholds
- package lint: publint and Are The Types Wrong passed
- packed compatibility: Node, Chromium, Firefox, WebKit, and Bun passed
- standalone Knip reported only the two pre-existing baseline findings removed by #112, with no findings from this PR

## Complexity

Medium: one domain module, four operations, two client adapters, and deterministic request/response/error validation.
