### PR TITLE
docs(sdk): document missing endpoint slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Upload targets `upload.put.io` internally because `api.put.io/v2/files/upload` i
 
 ## Folder Sort and Podcast Feeds
 
-Folder sort settings apply to subsequent file listings:
+Folder sort settings persist per folder and apply to subsequent file listings:
 
 ```ts
 await sdk.files.setSort({
@@ -317,6 +317,8 @@ await sdk.files.setSort({
 
 await sdk.files.resetSortSettings();
 ```
+
+`resetSortSettings()` clears the saved sort setting for every folder, including the root folder.
 
 Podcast links can target a folder and an explicit non-empty selection of feed types. Omit
 `types` to request the API defaults:

--- a/README.md
+++ b/README.md
@@ -305,6 +305,32 @@ const upload = await sdk.files.upload({
 
 Upload targets `upload.put.io` internally because `api.put.io/v2/files/upload` is only a redirect shim.
 
+## Folder Sort and Podcast Feeds
+
+Folder sort settings apply to subsequent file listings:
+
+```ts
+await sdk.files.setSort({
+  fileId: folderId,
+  sortBy: "MODIFIED_DESC",
+});
+
+await sdk.files.resetSortSettings();
+```
+
+Podcast links can target a folder and an explicit non-empty selection of feed types. Omit
+`types` to request the API defaults:
+
+```ts
+const { links, token } = await sdk.podcast.getLinks({
+  parentId: folderId,
+  types: ["audio", "mp4"],
+});
+```
+
+`links` is a partial map keyed by `all`, `audio`, `video`, and `mp4`, so consumers should
+check whether a requested link is present.
+
 ## TanStack Query
 
 The Promise client plugs into TanStack Query directly:


### PR DESCRIPTION
## Summary

Documents the missing-endpoint slices added by the two preceding PRs in this stack.

## Changed

- add `podcast` to the public namespace table
- document folder sort persistence and reset usage
- document podcast type selection and partial-link handling

## Review aids

```text
files.setSort / files.resetSortSettings
                +
podcast.getLinks({ parentId, types? })
                -> README consumer examples
```

## Risks

None to runtime behavior. Documentation-only stack cap.

## Verification

- `pnpm exec vp check .`
- examples checked against the exported Promise client surface

## Complexity

Documentation-only.

Part of #108.