### PR TITLE
fix(account): validate outbound request inputs

### DIFF
--- a/src/domains/account.spec.ts
+++ b/src/domains/account.spec.ts
@@ -292,6 +292,7 @@ describe("account domain", () => {
         handler,
       ),
     );
+    const emptyPassword = expectFailure(await runSdkExit(destroyAccount(""), handler));
     const invalidConfirmationSubject = expectFailure(
       await runSdkExit(
         // @ts-expect-error JavaScript callers can supply unknown confirmation subjects.
@@ -306,6 +307,7 @@ describe("account domain", () => {
     expect(unknownSetting).toBeInstanceOf(PutioValidationError);
     expect(incompleteClearOptions).toBeInstanceOf(PutioValidationError);
     expect(invalidPassword).toBeInstanceOf(PutioValidationError);
+    expect(emptyPassword).toBeInstanceOf(PutioValidationError);
     expect(invalidConfirmationSubject).toBeInstanceOf(PutioValidationError);
     expect(requestCount).toBe(0);
   });

--- a/src/domains/account.spec.ts
+++ b/src/domains/account.spec.ts
@@ -214,6 +214,100 @@ describe("account domain", () => {
     );
 
     expect(result).toEqual({ status: "OK" });
+
+    const twoFactorResult = await runSdkEffect(
+      saveAccountSettings({
+        two_factor_enabled: {
+          code: "123456",
+          enable: true,
+        },
+      }),
+      (request) => {
+        expect(getJsonBody(request)).toEqual({
+          two_factor_enabled: {
+            code: "123456",
+            enable: true,
+          },
+        });
+        return jsonResponse({ status: "OK" });
+      },
+      { accessToken: "token-123" },
+    );
+
+    expect(twoFactorResult).toEqual({ status: "OK" });
+  });
+
+  it("rejects invalid account request inputs before transport", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+
+    const invalidQuery = expectFailure(
+      await runSdkExit(
+        // @ts-expect-error JavaScript callers can still supply invalid query flags.
+        getAccountInfo({ download_token: 2 }),
+        handler,
+      ),
+    );
+    const invalidNestedSettings = expectFailure(
+      await runSdkExit(
+        saveAccountSettings({
+          two_factor_enabled: {
+            code: "123456",
+            // @ts-expect-error JavaScript callers can still supply invalid nested values.
+            enable: "yes",
+          },
+        }),
+        handler,
+      ),
+    );
+    const invalidSubtitleCount = expectFailure(
+      await runSdkExit(
+        saveAccountSettings({
+          subtitle_languages: ["en", "tr", "de"],
+        }),
+        handler,
+      ),
+    );
+    const unknownSetting = expectFailure(
+      await runSdkExit(
+        // @ts-expect-error JavaScript callers can supply unknown settings.
+        saveAccountSettings({ unknown_setting: true }),
+        handler,
+      ),
+    );
+    const incompleteClearOptions = expectFailure(
+      await runSdkExit(
+        // @ts-expect-error JavaScript callers can omit required clear flags.
+        clearAccount({ files: true }),
+        handler,
+      ),
+    );
+    const invalidPassword = expectFailure(
+      await runSdkExit(
+        // @ts-expect-error JavaScript callers can supply non-string passwords.
+        destroyAccount(123),
+        handler,
+      ),
+    );
+    const invalidConfirmationSubject = expectFailure(
+      await runSdkExit(
+        // @ts-expect-error JavaScript callers can supply unknown confirmation subjects.
+        listAccountConfirmations("username_change"),
+        handler,
+      ),
+    );
+
+    expect(invalidQuery).toBeInstanceOf(PutioValidationError);
+    expect(invalidNestedSettings).toBeInstanceOf(PutioValidationError);
+    expect(invalidSubtitleCount).toBeInstanceOf(PutioValidationError);
+    expect(unknownSetting).toBeInstanceOf(PutioValidationError);
+    expect(incompleteClearOptions).toBeInstanceOf(PutioValidationError);
+    expect(invalidPassword).toBeInstanceOf(PutioValidationError);
+    expect(invalidConfirmationSubject).toBeInstanceOf(PutioValidationError);
+    expect(requestCount).toBe(0);
   });
 
   it("lists supported subtitle languages", async () => {

--- a/src/domains/account.spec.ts
+++ b/src/domains/account.spec.ts
@@ -215,6 +215,29 @@ describe("account domain", () => {
 
     expect(result).toEqual({ status: "OK" });
 
+    const combinedResult = await runSdkEffect(
+      saveAccountSettings({
+        current_password: "current-secret",
+        locale: "tr",
+        mail: "sdk-next@put.io",
+        theme: "auto",
+        username: "sdk-next",
+      }),
+      (request) => {
+        expect(getJsonBody(request)).toEqual({
+          current_password: "current-secret",
+          locale: "tr",
+          mail: "sdk-next@put.io",
+          theme: "auto",
+          username: "sdk-next",
+        });
+        return jsonResponse({ status: "OK" });
+      },
+      { accessToken: "token-123" },
+    );
+
+    expect(combinedResult).toEqual({ status: "OK" });
+
     const twoFactorResult = await runSdkEffect(
       saveAccountSettings({
         two_factor_enabled: {
@@ -263,6 +286,17 @@ describe("account domain", () => {
         handler,
       ),
     );
+    const sensitiveSettings = "settings-secret-value";
+    const invalidSensitiveSettings = expectFailure(
+      await runSdkExit(
+        saveAccountSettings({
+          current_password: sensitiveSettings,
+          // @ts-expect-error JavaScript callers can supply non-string mail values.
+          mail: { value: sensitiveSettings },
+        }),
+        handler,
+      ),
+    );
     const invalidSubtitleCount = expectFailure(
       await runSdkExit(
         saveAccountSettings({
@@ -288,7 +322,7 @@ describe("account domain", () => {
     const invalidPassword = expectFailure(
       await runSdkExit(
         // @ts-expect-error JavaScript callers can supply non-string passwords.
-        destroyAccount(123),
+        destroyAccount({ value: "destroy-secret-value" }),
         handler,
       ),
     );
@@ -303,10 +337,26 @@ describe("account domain", () => {
 
     expect(invalidQuery).toBeInstanceOf(PutioValidationError);
     expect(invalidNestedSettings).toBeInstanceOf(PutioValidationError);
+    expect(invalidSensitiveSettings).toMatchObject({
+      cause: {
+        domain: "account",
+        operation: "saveSettings",
+        reason: "Invalid request input",
+      },
+    });
+    expect(JSON.stringify(invalidSensitiveSettings)).not.toContain(sensitiveSettings);
     expect(invalidSubtitleCount).toBeInstanceOf(PutioValidationError);
     expect(unknownSetting).toBeInstanceOf(PutioValidationError);
     expect(incompleteClearOptions).toBeInstanceOf(PutioValidationError);
     expect(invalidPassword).toBeInstanceOf(PutioValidationError);
+    expect(invalidPassword).toMatchObject({
+      cause: {
+        domain: "account",
+        operation: "destroy",
+        reason: "Invalid request input",
+      },
+    });
+    expect(JSON.stringify(invalidPassword)).not.toContain("destroy-secret-value");
     expect(emptyPassword).toBeInstanceOf(PutioValidationError);
     expect(invalidConfirmationSubject).toBeInstanceOf(PutioValidationError);
     expect(requestCount).toBe(0);

--- a/src/domains/account.ts
+++ b/src/domains/account.ts
@@ -116,7 +116,7 @@ export const AccountTwoFactorSettingsSchema = Schema.Struct({
   code: Schema.String,
   enable: Schema.Boolean,
 });
-const AccountSettingsPatchSchema = Schema.Struct({
+const AccountSettingsPatchFields = {
   beta_user: Schema.optional(AccountSettingsFields.beta_user),
   callback_url: Schema.optional(AccountSettingsFields.callback_url),
   dark_theme: Schema.optional(AccountSettingsFields.dark_theme),
@@ -143,22 +143,25 @@ const AccountSettingsPatchSchema = Schema.Struct({
   use_private_download_ip: Schema.optional(AccountSettingsFields.use_private_download_ip),
   use_start_from: Schema.optional(AccountSettingsFields.use_start_from),
   video_player: Schema.optional(AccountSettingsFields.video_player),
-});
+};
+const SaveAccountSettingsCommonFields = {
+  ...AccountSettingsPatchFields,
+  two_factor_enabled: Schema.optional(AccountTwoFactorSettingsSchema),
+  username: Schema.optional(Schema.String),
+};
 export const SaveAccountSettingsPayloadSchema = Schema.Union([
-  AccountSettingsPatchSchema,
+  Schema.Struct(SaveAccountSettingsCommonFields),
   Schema.Struct({
-    username: Schema.String,
-  }),
-  Schema.Struct({
+    ...SaveAccountSettingsCommonFields,
     current_password: Schema.String,
     mail: Schema.String,
+    password: Schema.optional(Schema.String),
   }),
   Schema.Struct({
+    ...SaveAccountSettingsCommonFields,
     current_password: Schema.String,
+    mail: Schema.optional(Schema.String),
     password: Schema.String,
-  }),
-  Schema.Struct({
-    two_factor_enabled: AccountTwoFactorSettingsSchema,
   }),
 ]);
 export const AccountClearOptionsSchema = Schema.Struct({
@@ -237,6 +240,14 @@ const failMissingField = (field: string): Effect.Effect<never, PutioValidationEr
 const widenValidationError = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E | PutioValidationError, R> => effect;
+const mapSensitiveAccountDecodeError = (operation: "destroy" | "saveSettings") => () =>
+  new PutioValidationError({
+    cause: {
+      domain: "account",
+      operation,
+      reason: "Invalid request input",
+    },
+  });
 const hasDownloadToken = (
   value: AccountInfoBroad,
 ): value is AccountInfoBroad & {
@@ -424,7 +435,7 @@ export const saveAccountSettings = (
   Schema.decodeUnknownEffect(SaveAccountSettingsPayloadSchema, {
     onExcessProperty: "error",
   })(payload).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.mapError(mapSensitiveAccountDecodeError("saveSettings")),
     Effect.flatMap((decodedPayload) =>
       requestJson(OkResponseSchema, {
         body: {
@@ -459,7 +470,7 @@ export const destroyAccount = (
   currentPassword: string,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> =>
   Schema.decodeUnknownEffect(Schema.String.check(Schema.isMinLength(1)))(currentPassword).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.mapError(mapSensitiveAccountDecodeError("destroy")),
     Effect.flatMap((decodedPassword) =>
       requestJson(OkResponseSchema, {
         body: {

--- a/src/domains/account.ts
+++ b/src/domains/account.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from "effect";
 import {
   PutioValidationError,
   definePutioOperationErrorSpec,
+  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
   type PutioSdkError,
@@ -170,9 +171,14 @@ export const AccountClearOptionsSchema = Schema.Struct({
   rss_logs: Schema.Boolean,
   trash: Schema.Boolean,
 });
+const AccountConfirmationSubjectSchema = Schema.Literals([
+  "mail_change",
+  "password_change",
+  "subscription_upgrade",
+]);
 export const AccountConfirmationSchema = Schema.Struct({
   created_at: Schema.String,
-  subject: Schema.Literals(["mail_change", "password_change", "subscription_upgrade"]),
+  subject: AccountConfirmationSubjectSchema,
 });
 const AccountConfirmationsEnvelopeSchema = Schema.Struct({
   confirmations: Schema.Array(AccountConfirmationSchema),
@@ -376,12 +382,19 @@ export function getAccountInfo(
   query: AccountInfoQuery,
 ): Effect.Effect<AccountInfoBroad, PutioSdkError, PutioSdkContext>;
 export function getAccountInfo(query: AccountInfoQuery = {}) {
-  const effect = requestJson(AccountInfoEnvelopeSchema, {
-    method: "GET",
-    path: "/v2/account/info",
-    query,
-  }).pipe(selectJsonField("info"));
-  return ensureAccountInfoFields(effect, query);
+  return Schema.decodeUnknownEffect(AccountInfoQuerySchema, {
+    onExcessProperty: "error",
+  })(query).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedQuery) => {
+      const effect = requestJson(AccountInfoEnvelopeSchema, {
+        method: "GET",
+        path: "/v2/account/info",
+        query: decodedQuery,
+      }).pipe(selectJsonField("info"));
+      return ensureAccountInfoFields(effect, decodedQuery);
+    }),
+  );
 }
 export const getAccountSettings = (): Effect.Effect<
   AccountSettings,
@@ -408,47 +421,74 @@ export const saveAccountSettings = (
   SaveAccountSettingsError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "json",
-      value: payload,
-    },
-    method: "POST",
-    path: "/v2/account/settings",
-  }).pipe(withOperationErrors(SaveAccountSettingsErrorSpec));
+  Schema.decodeUnknownEffect(SaveAccountSettingsPayloadSchema, {
+    onExcessProperty: "error",
+  })(payload).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedPayload) =>
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "json",
+          value: decodedPayload,
+        },
+        method: "POST",
+        path: "/v2/account/settings",
+      }),
+    ),
+    withOperationErrors(SaveAccountSettingsErrorSpec),
+  );
 export const clearAccount = (
   options: AccountClearOptions,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: options,
-    },
-    method: "POST",
-    path: "/v2/account/clear",
-  });
+  Schema.decodeUnknownEffect(AccountClearOptionsSchema, {
+    onExcessProperty: "error",
+  })(options).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedOptions) =>
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "form",
+          value: decodedOptions,
+        },
+        method: "POST",
+        path: "/v2/account/clear",
+      }),
+    ),
+  );
 export const destroyAccount = (
   currentPassword: string,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: {
-        current_password: currentPassword,
-      },
-    },
-    method: "POST",
-    path: "/v2/account/destroy",
-  });
+  Schema.decodeUnknownEffect(Schema.String)(currentPassword).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedPassword) =>
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "form",
+          value: {
+            current_password: decodedPassword,
+          },
+        },
+        method: "POST",
+        path: "/v2/account/destroy",
+      }),
+    ),
+  );
 export const listAccountConfirmations = (
   subject?: AccountConfirmation["subject"],
 ): Effect.Effect<ReadonlyArray<AccountConfirmation>, AccountConfirmationsError, PutioSdkContext> =>
-  requestJson(AccountConfirmationsEnvelopeSchema, {
-    method: "GET",
-    path: "/v2/account/confirmation/list",
-    query: subject
-      ? {
-          type: subject,
-        }
-      : undefined,
-  }).pipe(selectJsonField("confirmations"), withOperationErrors(AccountConfirmationsErrorSpec));
+  Schema.decodeUnknownEffect(Schema.UndefinedOr(AccountConfirmationSubjectSchema))(subject).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedSubject) =>
+      requestJson(AccountConfirmationsEnvelopeSchema, {
+        method: "GET",
+        path: "/v2/account/confirmation/list",
+        query: decodedSubject
+          ? {
+              type: decodedSubject,
+            }
+          : undefined,
+      }),
+    ),
+    selectJsonField("confirmations"),
+    withOperationErrors(AccountConfirmationsErrorSpec),
+  );

--- a/src/domains/account.ts
+++ b/src/domains/account.ts
@@ -458,7 +458,7 @@ export const clearAccount = (
 export const destroyAccount = (
   currentPassword: string,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(Schema.String)(currentPassword).pipe(
+  Schema.decodeUnknownEffect(Schema.String.check(Schema.isMinLength(1)))(currentPassword).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedPassword) =>
       requestJson(OkResponseSchema, {


### PR DESCRIPTION
## Summary

Enforces the account domain request schemas at the outbound boundary.

## Changed

- decode account-info queries before building query parameters
- decode account settings with excess-property rejection while preserving nested JSON
- decode all required account-clear flags before form serialization
- validate destroy-account passwords and confirmation subjects before requests
- map every decode failure to `PutioValidationError`
- cover invalid JavaScript inputs and assert zero transport calls

## Review aids

```text
unknown input
  -> Effect schema decode (including nested values and excess keys)
     -> PutioValidationError
     OR
     -> query / JSON / form serialization -> transport
```

The nested two-factor example asserts that schema validation does not regress the intentional JSON request encoding.

## Risks

Medium-low. Invalid runtime values now fail locally as promised by the package contract; valid request wire formats are unchanged and covered exactly.

## Verification

- `pnpm exec vp run verify` (20 files / 97 tests plus coverage)
- `pnpm exec vp run lint:package`
- `pnpm exec vp run test:compat`

## Complexity

Medium: five account request boundaries and one union-shaped settings payload.

Part of #108.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add strict input validation to all account SDK requests to fail fast before any network call and return `PutioValidationError`. Sanitize errors for sensitive operations and allow combined settings payloads without exposing secrets; reject empty destroy passwords.

- **Bug Fixes**
  - Validate and reject invalid or excess inputs for `getAccountInfo`, `saveAccountSettings`, `clearAccount`, `destroyAccount`, and `listAccountConfirmations` before transport; map failures to `PutioValidationError`.
  - Redact secrets in validation errors for `saveAccountSettings` and `destroyAccount` with a domain/operation-specific cause.
  - Accept combined settings payloads (username, mail, locale, theme, 2FA) while preserving nested JSON encoding.
  - Enforce non-empty `current_password` in `destroyAccount`.
  - Restrict confirmation subjects to supported types; invalid inputs never trigger transport.

<sup>Written for commit 3a4e95852ad8d9247cb1bc118f302f0b3d0cfae1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

