### PR TITLE
fix(config): validate JSON request boundaries

### DIFF
--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -1,5 +1,5 @@
 import { Effect, Schema } from "effect";
-import type { PutioSdkError } from "../core/errors.js";
+import { mapDecodeErrorToValidationError, type PutioSdkError } from "../core/errors.js";
 import {
   OkResponseSchema,
   encodePathSegment,
@@ -17,25 +17,45 @@ export type PutioJsonValue =
 export type PutioJsonObject = {
   readonly [key: string]: PutioJsonValue;
 };
-const isJsonValue = (value: unknown): value is PutioJsonValue => {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
+const isPlainRecord = (value: object): value is Record<string, unknown> => {
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  } catch {
+    return false;
+  }
+};
+const isJsonValue = (
+  value: unknown,
+  ancestors: ReadonlySet<object> = new Set(),
+): value is PutioJsonValue => {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
     return true;
   }
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
+  if (typeof value === "number") {
+    return Number.isFinite(value);
   }
-  if (typeof value === "object") {
-    return Object.values(value).every(isJsonValue);
+  if (typeof value !== "object" || ancestors.has(value)) {
+    return false;
   }
-  return false;
+  const descendants = new Set(ancestors).add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.every((item) => isJsonValue(item, descendants));
+    }
+    return (
+      isPlainRecord(value) && Object.values(value).every((item) => isJsonValue(item, descendants))
+    );
+  } catch {
+    return false;
+  }
 };
 const isJsonObject = (value: unknown): value is PutioJsonObject =>
-  typeof value === "object" && value !== null && !Array.isArray(value) && isJsonValue(value);
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  isPlainRecord(value) &&
+  isJsonValue(value);
 export const JsonValueSchema = Schema.Unknown.pipe(
   Schema.refine(isJsonValue, {
     expected: "a JSON-compatible value",
@@ -46,6 +66,11 @@ export const JsonObjectSchema = Schema.Unknown.pipe(
     expected: "a JSON object",
   }),
 );
+const ConfigKeySchema = Schema.String.check(Schema.isMinLength(1));
+const ConfigSetKeyInputSchema = Schema.Struct({
+  key: ConfigKeySchema,
+  value: JsonValueSchema,
+});
 const ConfigEnvelopeSchema = Schema.Struct({
   config: JsonObjectSchema,
   status: Schema.Literal("OK"),
@@ -75,55 +100,82 @@ export const readConfigWith = <A>(
 export const writeConfig = (
   config: PutioJsonObject,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "json",
-      value: {
-        config,
-      },
-    },
-    method: "PUT",
-    path: "/v2/config",
-  });
+  Schema.decodeUnknownEffect(JsonObjectSchema)(config).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedConfig) =>
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "json",
+          value: {
+            config: decodedConfig,
+          },
+        },
+        method: "PUT",
+        path: "/v2/config",
+      }),
+    ),
+  );
 export const getConfigKey = (
   key: string,
 ): Effect.Effect<PutioJsonValue, PutioSdkError, PutioSdkContext> =>
-  requestJson(ConfigValueEnvelopeSchema, {
-    method: "GET",
-    path: `/v2/config/${encodePathSegment(key)}`,
-  }).pipe(selectJsonField("value"));
+  Schema.decodeUnknownEffect(ConfigKeySchema)(key).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedKey) =>
+      requestJson(ConfigValueEnvelopeSchema, {
+        method: "GET",
+        path: `/v2/config/${encodePathSegment(decodedKey)}`,
+      }),
+    ),
+    selectJsonField("value"),
+  );
 export const getConfigKeyWith = <A>(
   key: string,
   schema: Schema.ConstraintDecoder<A, never>,
 ): Effect.Effect<A, PutioSdkError, PutioSdkContext> =>
-  requestJson(
-    Schema.Struct({
-      status: Schema.Literal("OK"),
-      value: schema,
-    }),
-    {
-      method: "GET",
-      path: `/v2/config/${encodePathSegment(key)}`,
-    },
-  ).pipe(Effect.map((envelope) => envelope["value"]));
+  Schema.decodeUnknownEffect(ConfigKeySchema)(key).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedKey) =>
+      requestJson(
+        Schema.Struct({
+          status: Schema.Literal("OK"),
+          value: schema,
+        }),
+        {
+          method: "GET",
+          path: `/v2/config/${encodePathSegment(decodedKey)}`,
+        },
+      ),
+    ),
+    Effect.map((envelope) => envelope["value"]),
+  );
 export const setConfigKey = (
   key: string,
   value: PutioJsonValue,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "json",
-      value: {
-        value,
-      },
-    },
-    method: "PUT",
-    path: `/v2/config/${encodePathSegment(key)}`,
-  });
+  Schema.decodeUnknownEffect(ConfigSetKeyInputSchema)({ key, value }).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "json",
+          value: {
+            value: decodedInput.value,
+          },
+        },
+        method: "PUT",
+        path: `/v2/config/${encodePathSegment(decodedInput.key)}`,
+      }),
+    ),
+  );
 export const deleteConfigKey = (
   key: string,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    method: "DELETE",
-    path: `/v2/config/${encodePathSegment(key)}`,
-  });
+  Schema.decodeUnknownEffect(ConfigKeySchema)(key).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedKey) =>
+      requestJson(OkResponseSchema, {
+        method: "DELETE",
+        path: `/v2/config/${encodePathSegment(decodedKey)}`,
+      }),
+    ),
+  );

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -20,14 +20,14 @@ export type PutioJsonObject = {
 const isPlainRecord = (value: object): value is Record<string, unknown> => {
   try {
     const prototype = Object.getPrototypeOf(value);
-    return prototype === Object.prototype || prototype === null;
+    return prototype === null || Object.getPrototypeOf(prototype) === null;
   } catch {
     return false;
   }
 };
 const snapshotJsonValue = (
   value: unknown,
-  ancestors: ReadonlySet<object> = new Set(),
+  ancestors: Set<object> = new Set(),
 ): PutioJsonValue | undefined => {
   if (value === null || typeof value === "string" || typeof value === "boolean") {
     return value;
@@ -38,7 +38,7 @@ const snapshotJsonValue = (
   if (typeof value !== "object" || ancestors.has(value)) {
     return undefined;
   }
-  const descendants = new Set(ancestors).add(value);
+  ancestors.add(value);
   try {
     if (Array.isArray(value)) {
       const output: Array<PutioJsonValue> = [];
@@ -47,7 +47,7 @@ const snapshotJsonValue = (
         if (descriptor === undefined || !("value" in descriptor)) {
           return undefined;
         }
-        const item = snapshotJsonValue(descriptor.value, descendants);
+        const item = snapshotJsonValue(descriptor.value, ancestors);
         if (item === undefined) {
           return undefined;
         }
@@ -66,7 +66,7 @@ const snapshotJsonValue = (
       if (!("value" in descriptor)) {
         return undefined;
       }
-      const item = snapshotJsonValue(descriptor.value, descendants);
+      const item = snapshotJsonValue(descriptor.value, ancestors);
       if (item === undefined) {
         return undefined;
       }
@@ -80,6 +80,8 @@ const snapshotJsonValue = (
     return output;
   } catch {
     return undefined;
+  } finally {
+    ancestors.delete(value);
   }
 };
 const snapshotJsonObject = (value: unknown): PutioJsonObject | undefined => {

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -18,6 +18,19 @@ export type PutioJsonObject = {
   readonly [key: string]: PutioJsonValue;
 };
 const nativeObjectConstructorSource = Function.prototype.toString.call(Object);
+const nativeArrayConstructorSource = Function.prototype.toString.call(Array);
+const hasMatchingNativeConstructor = (prototype: object, constructorSource: string): boolean => {
+  const constructor = Object.getOwnPropertyDescriptor(prototype, "constructor")?.value;
+  const constructorPrototype =
+    typeof constructor === "function"
+      ? Object.getOwnPropertyDescriptor(constructor, "prototype")?.value
+      : undefined;
+  return (
+    typeof constructor === "function" &&
+    constructorPrototype === prototype &&
+    Function.prototype.toString.call(constructor) === constructorSource
+  );
+};
 const isPlainRecord = (value: object): value is Record<string, unknown> => {
   try {
     const prototype = Object.getPrototypeOf(value);
@@ -27,15 +40,18 @@ const isPlainRecord = (value: object): value is Record<string, unknown> => {
     if (Object.getPrototypeOf(prototype) !== null) {
       return false;
     }
-    const constructor = Object.getOwnPropertyDescriptor(prototype, "constructor")?.value;
-    const constructorPrototype =
-      typeof constructor === "function"
-        ? Object.getOwnPropertyDescriptor(constructor, "prototype")?.value
-        : undefined;
+    return hasMatchingNativeConstructor(prototype, nativeObjectConstructorSource);
+  } catch {
+    return false;
+  }
+};
+const isPlainArray = (value: ReadonlyArray<unknown>): boolean => {
+  try {
+    const prototype = Object.getPrototypeOf(value);
     return (
-      typeof constructor === "function" &&
-      constructorPrototype === prototype &&
-      Function.prototype.toString.call(constructor) === nativeObjectConstructorSource
+      prototype !== null &&
+      Object.getPrototypeOf(prototype) !== null &&
+      hasMatchingNativeConstructor(prototype, nativeArrayConstructorSource)
     );
   } catch {
     return false;
@@ -69,9 +85,22 @@ const walkJsonValue = (
   ancestors.add(value);
   try {
     if (Array.isArray(value)) {
+      if (!isPlainArray(value)) {
+        return invalidJsonWalk;
+      }
+      const descriptors = Object.getOwnPropertyDescriptors(value);
+      const lengthDescriptor = descriptors["length"];
+      if (
+        lengthDescriptor === undefined ||
+        !("value" in lengthDescriptor) ||
+        !Number.isSafeInteger(lengthDescriptor.value) ||
+        lengthDescriptor.value < 0
+      ) {
+        return invalidJsonWalk;
+      }
       const output: Array<PutioJsonValue> | undefined = mode === "snapshot" ? [] : undefined;
-      for (let index = 0; index < value.length; index += 1) {
-        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      for (let index = 0; index < lengthDescriptor.value; index += 1) {
+        const descriptor = descriptors[String(index)];
         if (descriptor === undefined || !("value" in descriptor)) {
           return invalidJsonWalk;
         }

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -1,4 +1,4 @@
-import { Effect, Option, Schema, SchemaIssue } from "effect";
+import { Effect, Option, Schema, SchemaIssue, SchemaParser } from "effect";
 import { mapDecodeErrorToValidationError, type PutioSdkError } from "../core/errors.js";
 import {
   OkResponseSchema,
@@ -28,8 +28,13 @@ const isPlainRecord = (value: object): value is Record<string, unknown> => {
       return false;
     }
     const constructor = Object.getOwnPropertyDescriptor(prototype, "constructor")?.value;
+    const constructorPrototype =
+      typeof constructor === "function"
+        ? Object.getOwnPropertyDescriptor(constructor, "prototype")?.value
+        : undefined;
     return (
       typeof constructor === "function" &&
+      constructorPrototype === prototype &&
       Function.prototype.toString.call(constructor) === nativeObjectConstructorSource
     );
   } catch {
@@ -194,14 +199,60 @@ const ConfigSetKeyInputSchema = Schema.Struct({
   key: ConfigKeySchema,
   value: JsonValueSchema,
 });
-const ConfigEnvelopeSchema = Schema.Struct({
-  config: JsonObjectResponseSchema,
-  status: Schema.Literal("OK"),
-});
-const ConfigValueEnvelopeSchema = Schema.Struct({
-  status: Schema.Literal("OK"),
-  value: JsonValueResponseSchema,
-});
+const getResponseEnvelopeFields = (
+  input: unknown,
+  valueField: "config" | "value",
+): { readonly status: unknown; readonly value: unknown } | undefined => {
+  if (typeof input !== "object" || input === null || !isPlainRecord(input)) {
+    return undefined;
+  }
+  try {
+    const statusDescriptor = Object.getOwnPropertyDescriptor(input, "status");
+    const valueDescriptor = Object.getOwnPropertyDescriptor(input, valueField);
+    if (
+      statusDescriptor === undefined ||
+      !("value" in statusDescriptor) ||
+      valueDescriptor === undefined ||
+      !("value" in valueDescriptor)
+    ) {
+      return undefined;
+    }
+    return {
+      status: statusDescriptor.value,
+      value: valueDescriptor.value,
+    };
+  } catch {
+    return undefined;
+  }
+};
+const makeConfigEnvelopeSchema = <A>(schema: Schema.ConstraintDecoder<A, never>) =>
+  Schema.declareConstructor<{
+    readonly config: A;
+    readonly status: "OK";
+  }>()([schema], ([configSchema]) => (input, ast, options) => {
+    const fields = getResponseEnvelopeFields(input, "config");
+    if (fields === undefined || fields.status !== "OK") {
+      return Effect.fail(new SchemaIssue.InvalidType(ast, Option.none()));
+    }
+    return SchemaParser.decodeUnknownEffect(configSchema)(fields.value, options).pipe(
+      Effect.map((config) => ({ config, status: "OK" })),
+    );
+  });
+const makeConfigValueEnvelopeSchema = <A>(schema: Schema.ConstraintDecoder<A, never>) =>
+  Schema.declareConstructor<{
+    readonly status: "OK";
+    readonly value: A;
+  }>()([schema], ([valueSchema]) => (input, ast, options) => {
+    const fields = getResponseEnvelopeFields(input, "value");
+    if (fields === undefined || fields.status !== "OK") {
+      return Effect.fail(new SchemaIssue.InvalidType(ast, Option.none()));
+    }
+    return SchemaParser.decodeUnknownEffect(valueSchema)(fields.value, options).pipe(
+      Effect.map((value) => ({ status: "OK", value })),
+    );
+  });
+const ConfigEnvelopeSchema = makeConfigEnvelopeSchema(JsonObjectResponseSchema);
+const ConfigValueEnvelopeSchema = makeConfigValueEnvelopeSchema(JsonValueResponseSchema);
 export const readConfig = (): Effect.Effect<PutioJsonObject, PutioSdkError, PutioSdkContext> =>
   requestJson(ConfigEnvelopeSchema, {
     method: "GET",
@@ -210,16 +261,10 @@ export const readConfig = (): Effect.Effect<PutioJsonObject, PutioSdkError, Puti
 export const readConfigWith = <A>(
   schema: Schema.ConstraintDecoder<A, never>,
 ): Effect.Effect<A, PutioSdkError, PutioSdkContext> =>
-  requestJson(
-    Schema.Struct({
-      config: schema,
-      status: Schema.Literal("OK"),
-    }),
-    {
-      method: "GET",
-      path: "/v2/config",
-    },
-  ).pipe(Effect.map((envelope) => envelope["config"]));
+  requestJson(makeConfigEnvelopeSchema(JsonObjectResponseSchema.pipe(Schema.decodeTo(schema))), {
+    method: "GET",
+    path: "/v2/config",
+  }).pipe(Effect.map((envelope) => envelope["config"]));
 export const writeConfig = (
   config: PutioJsonObject,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> =>
@@ -259,10 +304,7 @@ export const getConfigKeyWith = <A>(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedKey) =>
       requestJson(
-        Schema.Struct({
-          status: Schema.Literal("OK"),
-          value: schema,
-        }),
+        makeConfigValueEnvelopeSchema(JsonValueResponseSchema.pipe(Schema.decodeTo(schema))),
         {
           method: "GET",
           path: `/v2/config/${encodePathSegment(decodedKey)}`,

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -122,7 +122,10 @@ export const JsonObjectSchema = Schema.declareConstructor<PutioJsonObject>()(
     expected: "a JSON object",
   },
 );
-const ConfigKeySchema = Schema.String.check(Schema.isMinLength(1));
+const ConfigKeySchema = Schema.String.check(
+  Schema.isMinLength(1),
+  Schema.isPattern(/^(?!\.{1,2}$)/),
+);
 const ConfigSetKeyInputSchema = Schema.Struct({
   key: ConfigKeySchema,
   value: JsonValueSchema,

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -25,37 +25,92 @@ const isPlainRecord = (value: object): value is Record<string, unknown> => {
     return false;
   }
 };
-const isJsonValue = (
+const snapshotJsonValue = (
   value: unknown,
   ancestors: ReadonlySet<object> = new Set(),
-): value is PutioJsonValue => {
+): PutioJsonValue | undefined => {
   if (value === null || typeof value === "string" || typeof value === "boolean") {
-    return true;
+    return value;
   }
   if (typeof value === "number") {
-    return Number.isFinite(value);
+    return Number.isFinite(value) ? value : undefined;
   }
   if (typeof value !== "object" || ancestors.has(value)) {
-    return false;
+    return undefined;
   }
   const descendants = new Set(ancestors).add(value);
   try {
     if (Array.isArray(value)) {
-      return value.every((item) => isJsonValue(item, descendants));
+      const output: Array<PutioJsonValue> = [];
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (descriptor === undefined || !("value" in descriptor)) {
+          return undefined;
+        }
+        const item = snapshotJsonValue(descriptor.value, descendants);
+        if (item === undefined) {
+          return undefined;
+        }
+        output.push(item);
+      }
+      return output;
     }
-    return (
-      isPlainRecord(value) && Object.values(value).every((item) => isJsonValue(item, descendants))
-    );
+    if (!isPlainRecord(value)) {
+      return undefined;
+    }
+    const output: Record<string, PutioJsonValue> = {};
+    for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(value))) {
+      if (!descriptor.enumerable) {
+        continue;
+      }
+      if (!("value" in descriptor)) {
+        return undefined;
+      }
+      const item = snapshotJsonValue(descriptor.value, descendants);
+      if (item === undefined) {
+        return undefined;
+      }
+      Object.defineProperty(output, key, {
+        configurable: true,
+        enumerable: true,
+        value: item,
+        writable: true,
+      });
+    }
+    return output;
   } catch {
-    return false;
+    return undefined;
   }
 };
+const isJsonValue = (value: unknown): value is PutioJsonValue =>
+  snapshotJsonValue(value) !== undefined;
 const isJsonObject = (value: unknown): value is PutioJsonObject =>
   typeof value === "object" &&
   value !== null &&
   !Array.isArray(value) &&
   isPlainRecord(value) &&
   isJsonValue(value);
+const snapshotJsonObject = (value: unknown): PutioJsonObject | undefined => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !isPlainRecord(value)
+  ) {
+    return undefined;
+  }
+  const snapshot = snapshotJsonValue(value);
+  return typeof snapshot === "object" && snapshot !== null && !Array.isArray(snapshot)
+    ? snapshot
+    : undefined;
+};
+const requireJsonSnapshot = <A extends PutioJsonValue>(
+  snapshot: A | undefined,
+  expected: string,
+): Effect.Effect<A, PutioSdkError> =>
+  snapshot === undefined
+    ? Effect.fail(mapDecodeErrorToValidationError(`Expected ${expected}`))
+    : Effect.succeed(snapshot);
 export const JsonValueSchema = Schema.Unknown.pipe(
   Schema.refine(isJsonValue, {
     expected: "a JSON-compatible value",
@@ -103,16 +158,20 @@ export const writeConfig = (
   Schema.decodeUnknownEffect(JsonObjectSchema)(config).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedConfig) =>
-      requestJson(OkResponseSchema, {
-        body: {
-          type: "json",
-          value: {
-            config: decodedConfig,
-          },
-        },
-        method: "PUT",
-        path: "/v2/config",
-      }),
+      requireJsonSnapshot(snapshotJsonObject(decodedConfig), "a JSON object").pipe(
+        Effect.flatMap((configSnapshot) =>
+          requestJson(OkResponseSchema, {
+            body: {
+              type: "json",
+              value: {
+                config: configSnapshot,
+              },
+            },
+            method: "PUT",
+            path: "/v2/config",
+          }),
+        ),
+      ),
     ),
   );
 export const getConfigKey = (
@@ -155,16 +214,20 @@ export const setConfigKey = (
   Schema.decodeUnknownEffect(ConfigSetKeyInputSchema)({ key, value }).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedInput) =>
-      requestJson(OkResponseSchema, {
-        body: {
-          type: "json",
-          value: {
-            value: decodedInput.value,
-          },
-        },
-        method: "PUT",
-        path: `/v2/config/${encodePathSegment(decodedInput.key)}`,
-      }),
+      requireJsonSnapshot(snapshotJsonValue(decodedInput.value), "a JSON-compatible value").pipe(
+        Effect.flatMap((valueSnapshot) =>
+          requestJson(OkResponseSchema, {
+            body: {
+              type: "json",
+              value: {
+                value: valueSnapshot,
+              },
+            },
+            method: "PUT",
+            path: `/v2/config/${encodePathSegment(decodedInput.key)}`,
+          }),
+        ),
+      ),
     ),
   );
 export const deleteConfigKey = (

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -17,10 +17,21 @@ export type PutioJsonValue =
 export type PutioJsonObject = {
   readonly [key: string]: PutioJsonValue;
 };
+const nativeObjectConstructorSource = Function.prototype.toString.call(Object);
 const isPlainRecord = (value: object): value is Record<string, unknown> => {
   try {
     const prototype = Object.getPrototypeOf(value);
-    return prototype === null || Object.getPrototypeOf(prototype) === null;
+    if (prototype === null) {
+      return true;
+    }
+    if (Object.getPrototypeOf(prototype) !== null) {
+      return false;
+    }
+    const constructor = Object.getOwnPropertyDescriptor(prototype, "constructor")?.value;
+    return (
+      typeof constructor === "function" &&
+      Function.prototype.toString.call(constructor) === nativeObjectConstructorSource
+    );
   } catch {
     return false;
   }

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -109,6 +109,58 @@ const snapshotJsonObject = (value: unknown): PutioJsonObject | undefined => {
     ? snapshot
     : undefined;
 };
+const isJsonValue = (
+  value: unknown,
+  ancestors: Set<object> = new Set(),
+): value is PutioJsonValue => {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return true;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  if (typeof value !== "object" || ancestors.has(value)) {
+    return false;
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (
+          descriptor === undefined ||
+          !("value" in descriptor) ||
+          !isJsonValue(descriptor.value, ancestors)
+        ) {
+          return false;
+        }
+      }
+      return true;
+    }
+    if (!isPlainRecord(value)) {
+      return false;
+    }
+    for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(value))) {
+      if (
+        descriptor.enumerable &&
+        (!("value" in descriptor) || !isJsonValue(descriptor.value, ancestors))
+      ) {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  } finally {
+    ancestors.delete(value);
+  }
+};
+const isJsonObject = (value: unknown): value is PutioJsonObject =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  isPlainRecord(value) &&
+  isJsonValue(value);
 export const JsonValueSchema = Schema.declareConstructor<PutioJsonValue>()(
   [],
   () => (input, ast) => {
@@ -119,6 +171,26 @@ export const JsonValueSchema = Schema.declareConstructor<PutioJsonValue>()(
   },
   {
     expected: "a JSON-compatible value",
+  },
+);
+const JsonValueResponseSchema = Schema.declareConstructor<PutioJsonValue>()(
+  [],
+  () => (input, ast) =>
+    isJsonValue(input)
+      ? Effect.succeed(input)
+      : Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input))),
+  {
+    expected: "a JSON-compatible value",
+  },
+);
+const JsonObjectResponseSchema = Schema.declareConstructor<PutioJsonObject>()(
+  [],
+  () => (input, ast) =>
+    isJsonObject(input)
+      ? Effect.succeed(input)
+      : Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input))),
+  {
+    expected: "a JSON object",
   },
 );
 export const JsonObjectSchema = Schema.declareConstructor<PutioJsonObject>()(
@@ -145,12 +217,12 @@ const ConfigSetKeyInputSchema = Schema.Struct({
   value: JsonValueSchema,
 });
 const ConfigEnvelopeSchema = Schema.Struct({
-  config: JsonObjectSchema,
+  config: JsonObjectResponseSchema,
   status: Schema.Literal("OK"),
 });
 const ConfigValueEnvelopeSchema = Schema.Struct({
   status: Schema.Literal("OK"),
-  value: JsonValueSchema,
+  value: JsonValueResponseSchema,
 });
 export const readConfig = (): Effect.Effect<PutioJsonObject, PutioSdkError, PutioSdkContext> =>
   requestJson(ConfigEnvelopeSchema, {

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect";
+import { Effect, Option, Schema, SchemaIssue } from "effect";
 import { mapDecodeErrorToValidationError, type PutioSdkError } from "../core/errors.js";
 import {
   OkResponseSchema,
@@ -82,14 +82,6 @@ const snapshotJsonValue = (
     return undefined;
   }
 };
-const isJsonValue = (value: unknown): value is PutioJsonValue =>
-  snapshotJsonValue(value) !== undefined;
-const isJsonObject = (value: unknown): value is PutioJsonObject =>
-  typeof value === "object" &&
-  value !== null &&
-  !Array.isArray(value) &&
-  isPlainRecord(value) &&
-  isJsonValue(value);
 const snapshotJsonObject = (value: unknown): PutioJsonObject | undefined => {
   if (
     typeof value !== "object" ||
@@ -104,22 +96,29 @@ const snapshotJsonObject = (value: unknown): PutioJsonObject | undefined => {
     ? snapshot
     : undefined;
 };
-const requireJsonSnapshot = <A extends PutioJsonValue>(
-  snapshot: A | undefined,
-  expected: string,
-): Effect.Effect<A, PutioSdkError> =>
-  snapshot === undefined
-    ? Effect.fail(mapDecodeErrorToValidationError(`Expected ${expected}`))
-    : Effect.succeed(snapshot);
-export const JsonValueSchema = Schema.Unknown.pipe(
-  Schema.refine(isJsonValue, {
+export const JsonValueSchema = Schema.declareConstructor<PutioJsonValue>()(
+  [],
+  () => (input, ast) => {
+    const snapshot = snapshotJsonValue(input);
+    return snapshot === undefined
+      ? Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input)))
+      : Effect.succeed(snapshot);
+  },
+  {
     expected: "a JSON-compatible value",
-  }),
+  },
 );
-export const JsonObjectSchema = Schema.Unknown.pipe(
-  Schema.refine(isJsonObject, {
+export const JsonObjectSchema = Schema.declareConstructor<PutioJsonObject>()(
+  [],
+  () => (input, ast) => {
+    const snapshot = snapshotJsonObject(input);
+    return snapshot === undefined
+      ? Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input)))
+      : Effect.succeed(snapshot);
+  },
+  {
     expected: "a JSON object",
-  }),
+  },
 );
 const ConfigKeySchema = Schema.String.check(Schema.isMinLength(1));
 const ConfigSetKeyInputSchema = Schema.Struct({
@@ -158,20 +157,16 @@ export const writeConfig = (
   Schema.decodeUnknownEffect(JsonObjectSchema)(config).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedConfig) =>
-      requireJsonSnapshot(snapshotJsonObject(decodedConfig), "a JSON object").pipe(
-        Effect.flatMap((configSnapshot) =>
-          requestJson(OkResponseSchema, {
-            body: {
-              type: "json",
-              value: {
-                config: configSnapshot,
-              },
-            },
-            method: "PUT",
-            path: "/v2/config",
-          }),
-        ),
-      ),
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "json",
+          value: {
+            config: decodedConfig,
+          },
+        },
+        method: "PUT",
+        path: "/v2/config",
+      }),
     ),
   );
 export const getConfigKey = (
@@ -214,20 +209,16 @@ export const setConfigKey = (
   Schema.decodeUnknownEffect(ConfigSetKeyInputSchema)({ key, value }).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedInput) =>
-      requireJsonSnapshot(snapshotJsonValue(decodedInput.value), "a JSON-compatible value").pipe(
-        Effect.flatMap((valueSnapshot) =>
-          requestJson(OkResponseSchema, {
-            body: {
-              type: "json",
-              value: {
-                value: valueSnapshot,
-              },
-            },
-            method: "PUT",
-            path: `/v2/config/${encodePathSegment(decodedInput.key)}`,
-          }),
-        ),
-      ),
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "json",
+          value: {
+            value: decodedInput.value,
+          },
+        },
+        method: "PUT",
+        path: `/v2/config/${encodePathSegment(decodedInput.key)}`,
+      }),
     ),
   );
 export const deleteConfigKey = (

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -96,14 +96,6 @@ const snapshotJsonValue = (
   }
 };
 const snapshotJsonObject = (value: unknown): PutioJsonObject | undefined => {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    Array.isArray(value) ||
-    !isPlainRecord(value)
-  ) {
-    return undefined;
-  }
   const snapshot = snapshotJsonValue(value);
   return typeof snapshot === "object" && snapshot !== null && !Array.isArray(snapshot)
     ? snapshot
@@ -158,15 +150,15 @@ const isJsonValue = (
 const isJsonObject = (value: unknown): value is PutioJsonObject =>
   typeof value === "object" &&
   value !== null &&
+  isJsonValue(value) &&
   !Array.isArray(value) &&
-  isPlainRecord(value) &&
-  isJsonValue(value);
+  isPlainRecord(value);
 export const JsonValueSchema = Schema.declareConstructor<PutioJsonValue>()(
   [],
   () => (input, ast) => {
     const snapshot = snapshotJsonValue(input);
     return snapshot === undefined
-      ? Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input)))
+      ? Effect.fail(new SchemaIssue.InvalidType(ast, Option.none()))
       : Effect.succeed(snapshot);
   },
   {
@@ -178,7 +170,7 @@ const JsonValueResponseSchema = Schema.declareConstructor<PutioJsonValue>()(
   () => (input, ast) =>
     isJsonValue(input)
       ? Effect.succeed(input)
-      : Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input))),
+      : Effect.fail(new SchemaIssue.InvalidType(ast, Option.none())),
   {
     expected: "a JSON-compatible value",
   },
@@ -188,7 +180,7 @@ const JsonObjectResponseSchema = Schema.declareConstructor<PutioJsonObject>()(
   () => (input, ast) =>
     isJsonObject(input)
       ? Effect.succeed(input)
-      : Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input))),
+      : Effect.fail(new SchemaIssue.InvalidType(ast, Option.none())),
   {
     expected: "a JSON object",
   },
@@ -198,7 +190,7 @@ export const JsonObjectSchema = Schema.declareConstructor<PutioJsonObject>()(
   () => (input, ast) => {
     const snapshot = snapshotJsonObject(input);
     return snapshot === undefined
-      ? Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input)))
+      ? Effect.fail(new SchemaIssue.InvalidType(ast, Option.none()))
       : Effect.succeed(snapshot);
   },
   {

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -125,6 +125,9 @@ export const JsonObjectSchema = Schema.declareConstructor<PutioJsonObject>()(
 const ConfigKeySchema = Schema.String.check(
   Schema.isMinLength(1),
   Schema.isPattern(/^(?!\.{1,2}$)/),
+  Schema.makeFilter((key: string) => key.isWellFormed(), {
+    expected: "a well-formed Unicode config key",
+  }),
 );
 const ConfigSetKeyInputSchema = Schema.Struct({
   key: ConfigKeySchema,

--- a/src/domains/config.ts
+++ b/src/domains/config.ts
@@ -36,64 +36,98 @@ const isPlainRecord = (value: object): value is Record<string, unknown> => {
     return false;
   }
 };
-const snapshotJsonValue = (
+type JsonWalkMode = "snapshot" | "validate";
+type JsonWalkResult =
+  | { readonly _tag: "Invalid" }
+  | { readonly _tag: "Validated" }
+  | { readonly _tag: "Snapshot"; readonly value: PutioJsonValue };
+const invalidJsonWalk: JsonWalkResult = { _tag: "Invalid" };
+const validatedJsonWalk: JsonWalkResult = { _tag: "Validated" };
+const walkJsonValue = (
   value: unknown,
+  mode: JsonWalkMode,
   ancestors: Set<object> = new Set(),
-): PutioJsonValue | undefined => {
+): JsonWalkResult => {
   if (value === null || typeof value === "string" || typeof value === "boolean") {
-    return value;
+    return mode === "snapshot" ? { _tag: "Snapshot", value } : validatedJsonWalk;
   }
   if (typeof value === "number") {
-    return Number.isFinite(value) ? value : undefined;
+    return Number.isFinite(value)
+      ? mode === "snapshot"
+        ? { _tag: "Snapshot", value }
+        : validatedJsonWalk
+      : invalidJsonWalk;
   }
   if (typeof value !== "object" || ancestors.has(value)) {
-    return undefined;
+    return invalidJsonWalk;
   }
   ancestors.add(value);
   try {
     if (Array.isArray(value)) {
-      const output: Array<PutioJsonValue> = [];
+      const output: Array<PutioJsonValue> | undefined = mode === "snapshot" ? [] : undefined;
       for (let index = 0; index < value.length; index += 1) {
         const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
         if (descriptor === undefined || !("value" in descriptor)) {
-          return undefined;
+          return invalidJsonWalk;
         }
-        const item = snapshotJsonValue(descriptor.value, ancestors);
-        if (item === undefined) {
-          return undefined;
+        const item = walkJsonValue(descriptor.value, mode, ancestors);
+        if (item._tag === "Invalid") {
+          return item;
         }
-        output.push(item);
+        if (output === undefined) {
+          if (item._tag !== "Validated") {
+            return invalidJsonWalk;
+          }
+        } else {
+          if (item._tag !== "Snapshot") {
+            return invalidJsonWalk;
+          }
+          output.push(item.value);
+        }
       }
-      return output;
+      return output === undefined ? validatedJsonWalk : { _tag: "Snapshot", value: output };
     }
     if (!isPlainRecord(value)) {
-      return undefined;
+      return invalidJsonWalk;
     }
-    const output: Record<string, PutioJsonValue> = {};
+    const output: Record<string, PutioJsonValue> | undefined = mode === "snapshot" ? {} : undefined;
     for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(value))) {
       if (!descriptor.enumerable) {
         continue;
       }
       if (!("value" in descriptor)) {
-        return undefined;
+        return invalidJsonWalk;
       }
-      const item = snapshotJsonValue(descriptor.value, ancestors);
-      if (item === undefined) {
-        return undefined;
+      const item = walkJsonValue(descriptor.value, mode, ancestors);
+      if (item._tag === "Invalid") {
+        return item;
+      }
+      if (output === undefined) {
+        if (item._tag !== "Validated") {
+          return invalidJsonWalk;
+        }
+        continue;
+      }
+      if (item._tag !== "Snapshot") {
+        return invalidJsonWalk;
       }
       Object.defineProperty(output, key, {
         configurable: true,
         enumerable: true,
-        value: item,
+        value: item.value,
         writable: true,
       });
     }
-    return output;
+    return output === undefined ? validatedJsonWalk : { _tag: "Snapshot", value: output };
   } catch {
-    return undefined;
+    return invalidJsonWalk;
   } finally {
     ancestors.delete(value);
   }
+};
+const snapshotJsonValue = (value: unknown): PutioJsonValue | undefined => {
+  const result = walkJsonValue(value, "snapshot");
+  return result._tag === "Snapshot" ? result.value : undefined;
 };
 const snapshotJsonObject = (value: unknown): PutioJsonObject | undefined => {
   const snapshot = snapshotJsonValue(value);
@@ -101,58 +135,10 @@ const snapshotJsonObject = (value: unknown): PutioJsonObject | undefined => {
     ? snapshot
     : undefined;
 };
-const isJsonValue = (
-  value: unknown,
-  ancestors: Set<object> = new Set(),
-): value is PutioJsonValue => {
-  if (value === null || typeof value === "string" || typeof value === "boolean") {
-    return true;
-  }
-  if (typeof value === "number") {
-    return Number.isFinite(value);
-  }
-  if (typeof value !== "object" || ancestors.has(value)) {
-    return false;
-  }
-  ancestors.add(value);
-  try {
-    if (Array.isArray(value)) {
-      for (let index = 0; index < value.length; index += 1) {
-        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
-        if (
-          descriptor === undefined ||
-          !("value" in descriptor) ||
-          !isJsonValue(descriptor.value, ancestors)
-        ) {
-          return false;
-        }
-      }
-      return true;
-    }
-    if (!isPlainRecord(value)) {
-      return false;
-    }
-    for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(value))) {
-      if (
-        descriptor.enumerable &&
-        (!("value" in descriptor) || !isJsonValue(descriptor.value, ancestors))
-      ) {
-        return false;
-      }
-    }
-    return true;
-  } catch {
-    return false;
-  } finally {
-    ancestors.delete(value);
-  }
-};
+const isJsonValue = (value: unknown): value is PutioJsonValue =>
+  walkJsonValue(value, "validate")._tag === "Validated";
 const isJsonObject = (value: unknown): value is PutioJsonObject =>
-  typeof value === "object" &&
-  value !== null &&
-  isJsonValue(value) &&
-  !Array.isArray(value) &&
-  isPlainRecord(value);
+  typeof value === "object" && value !== null && isJsonValue(value) && !Array.isArray(value);
 export const JsonValueSchema = Schema.declareConstructor<PutioJsonValue>()(
   [],
   () => (input, ast) => {

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -21,6 +21,16 @@ import {
   runSdkExit,
 } from "../../test/support/sdk-test.js";
 
+const inMemoryJsonResponse = (body: unknown): Response => {
+  const response = new Response(null, {
+    headers: { "content-type": "application/json" },
+  });
+  Object.defineProperty(response, "json", {
+    value: async () => body,
+  });
+  return response;
+};
+
 const sharedFile = {
   content_type: null,
   created_at: "2026-03-17T00:00:00Z",
@@ -93,12 +103,7 @@ describe("supporting domain boundaries", () => {
       },
       theme: "dark",
     };
-    const configResponse = new Response(null, {
-      headers: { "content-type": "application/json" },
-    });
-    Object.defineProperty(configResponse, "json", {
-      value: async () => ({ config: responseConfig, status: "OK" }),
-    });
+    const configResponse = inMemoryJsonResponse({ config: responseConfig, status: "OK" });
     const decodedConfig = await runSdkEffect(configDomain.readConfig(), () => configResponse, {
       accessToken: "token-123",
     });
@@ -162,12 +167,7 @@ describe("supporting domain boundaries", () => {
     ).toBe("dark");
 
     const responseValue = { enabled: true };
-    const valueResponse = new Response(null, {
-      headers: { "content-type": "application/json" },
-    });
-    Object.defineProperty(valueResponse, "json", {
-      value: async () => ({ status: "OK", value: responseValue }),
-    });
+    const valueResponse = inMemoryJsonResponse({ status: "OK", value: responseValue });
     const decodedValue = await runSdkEffect(
       configDomain.getConfigKey("feature"),
       () => valueResponse,
@@ -175,6 +175,15 @@ describe("supporting domain boundaries", () => {
     );
 
     expect(decodedValue).toBe(responseValue);
+
+    const responseArray = ["sdk", 1, false, null];
+    const decodedArray = await runSdkEffect(
+      configDomain.getConfigKey("array"),
+      () => inMemoryJsonResponse({ status: "OK", value: responseArray }),
+      { accessToken: "token-123" },
+    );
+
+    expect(decodedArray).toBe(responseArray);
 
     expect(
       await runSdkEffect(
@@ -298,6 +307,40 @@ describe("supporting domain boundaries", () => {
     expect(dotDeleteKey).toBeInstanceOf(PutioValidationError);
     expect(getterCalls).toBe(0);
     expect(requestCount).toBe(0);
+  });
+
+  it("rejects invalid config response values", async () => {
+    const cyclicValue: { self?: unknown } = {};
+    cyclicValue.self = cyclicValue;
+    const sparseValue: Array<unknown> = [];
+    sparseValue.length = 1;
+    const accessorValue = {};
+    Object.defineProperty(accessorValue, "value", {
+      enumerable: true,
+      get: () => 1,
+    });
+    const invalidValues = [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      () => "nope",
+      cyclicValue,
+      sparseValue,
+      accessorValue,
+      new Date(),
+    ];
+    const failures = await Promise.all(
+      invalidValues.map((value) =>
+        runSdkExit(
+          configDomain.getConfigKey("invalid"),
+          () => inMemoryJsonResponse({ status: "OK", value }),
+          { accessToken: "token-123" },
+        ),
+      ),
+    );
+
+    expect(
+      failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
   });
 
   it("covers download links and events", async () => {

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -95,6 +95,11 @@ describe("supporting domain boundaries", () => {
     const customPrototypeConfig: Record<string, unknown> = Object.create(customPrototype);
     customPrototypeConfig.locale = "en";
     expect(() => decodeJsonObject(customPrototypeConfig)).toThrow("Expected a JSON object");
+    const forgedPrototype: Record<string, unknown> = Object.create(null);
+    Object.defineProperty(forgedPrototype, "constructor", { value: Object });
+    const forgedPrototypeConfig: Record<string, unknown> = Object.create(forgedPrototype);
+    forgedPrototypeConfig.locale = "en";
+    expect(() => decodeJsonObject(forgedPrototypeConfig)).toThrow("Expected a JSON object");
     expect(() => decodeJsonObject(["nope"])).toThrow("Expected a JSON object");
 
     const responseConfig = {
@@ -336,6 +341,10 @@ describe("supporting domain boundaries", () => {
       enumerable: true,
       get: () => 1,
     });
+    const forgedPrototype: Record<string, unknown> = Object.create(null);
+    Object.defineProperty(forgedPrototype, "constructor", { value: Object });
+    const forgedValue: Record<string, unknown> = Object.create(forgedPrototype);
+    forgedValue.enabled = true;
     const invalidValues = [
       Number.NaN,
       Number.POSITIVE_INFINITY,
@@ -343,6 +352,7 @@ describe("supporting domain boundaries", () => {
       cyclicValue,
       sparseValue,
       accessorValue,
+      forgedValue,
       new Date(),
     ];
     const failures = await Promise.all(
@@ -373,6 +383,56 @@ describe("supporting domain boundaries", () => {
 
     expect(fullConfigFailure).toBeInstanceOf(PutioValidationError);
     expect(fullConfigRequestCount).toBe(1);
+
+    let envelopeGetterCalls = 0;
+    const valueEnvelope = { status: "OK" };
+    Object.defineProperty(valueEnvelope, "value", {
+      enumerable: true,
+      get: () => {
+        envelopeGetterCalls += 1;
+        return "unsafe";
+      },
+    });
+    const configEnvelope = { status: "OK" };
+    Object.defineProperty(configEnvelope, "config", {
+      enumerable: true,
+      get: () => {
+        envelopeGetterCalls += 1;
+        return {};
+      },
+    });
+    const valueEnvelopeFailure = expectFailure(
+      await runSdkExit(
+        configDomain.getConfigKey("accessor"),
+        () => inMemoryJsonResponse(valueEnvelope),
+        { accessToken: "token-123" },
+      ),
+    );
+    const configEnvelopeFailure = expectFailure(
+      await runSdkExit(configDomain.readConfig(), () => inMemoryJsonResponse(configEnvelope), {
+        accessToken: "token-123",
+      }),
+    );
+    const typedValueFailure = expectFailure(
+      await runSdkExit(
+        configDomain.getConfigKeyWith("typed-invalid", Schema.Unknown),
+        () => inMemoryJsonResponse({ status: "OK", value: new Date() }),
+        { accessToken: "token-123" },
+      ),
+    );
+    const typedConfigFailure = expectFailure(
+      await runSdkExit(
+        configDomain.readConfigWith(Schema.Unknown),
+        () => inMemoryJsonResponse({ config: new Date(), status: "OK" }),
+        { accessToken: "token-123" },
+      ),
+    );
+
+    expect(valueEnvelopeFailure).toBeInstanceOf(PutioValidationError);
+    expect(configEnvelopeFailure).toBeInstanceOf(PutioValidationError);
+    expect(typedValueFailure).toBeInstanceOf(PutioValidationError);
+    expect(typedConfigFailure).toBeInstanceOf(PutioValidationError);
+    expect(envelopeGetterCalls).toBe(0);
   });
 
   it("covers download links and events", async () => {

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -223,6 +223,9 @@ describe("supporting domain boundaries", () => {
     const emptyGetKey = expectFailure(
       await runSdkExit(configDomain.getConfigKey(""), invalidHandler),
     );
+    const dotGetKey = expectFailure(
+      await runSdkExit(configDomain.getConfigKey(".."), invalidHandler),
+    );
     const emptyTypedGetKey = expectFailure(
       await runSdkExit(
         configDomain.getConfigKeyWith("", configDomain.JsonValueSchema),
@@ -245,19 +248,28 @@ describe("supporting domain boundaries", () => {
     const emptySetKey = expectFailure(
       await runSdkExit(configDomain.setConfigKey("", "light"), invalidHandler),
     );
+    const dotSetKey = expectFailure(
+      await runSdkExit(configDomain.setConfigKey(".", "light"), invalidHandler),
+    );
     const emptyDeleteKey = expectFailure(
       await runSdkExit(configDomain.deleteConfigKey(""), invalidHandler),
+    );
+    const dotDeleteKey = expectFailure(
+      await runSdkExit(configDomain.deleteConfigKey(".."), invalidHandler),
     );
 
     expect(invalidConfig).toBeInstanceOf(PutioValidationError);
     expect(cyclicConfig).toBeInstanceOf(PutioValidationError);
     expect(emptyGetKey).toBeInstanceOf(PutioValidationError);
+    expect(dotGetKey).toBeInstanceOf(PutioValidationError);
     expect(emptyTypedGetKey).toBeInstanceOf(PutioValidationError);
     expect(invalidSetValue).toBeInstanceOf(PutioValidationError);
     expect(sparseSetValue).toBeInstanceOf(PutioValidationError);
     expect(accessorConfig).toBeInstanceOf(PutioValidationError);
     expect(emptySetKey).toBeInstanceOf(PutioValidationError);
+    expect(dotSetKey).toBeInstanceOf(PutioValidationError);
     expect(emptyDeleteKey).toBeInstanceOf(PutioValidationError);
+    expect(dotDeleteKey).toBeInstanceOf(PutioValidationError);
     expect(getterCalls).toBe(0);
     expect(requestCount).toBe(0);
   });

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -226,6 +226,9 @@ describe("supporting domain boundaries", () => {
     const dotGetKey = expectFailure(
       await runSdkExit(configDomain.getConfigKey(".."), invalidHandler),
     );
+    const malformedGetKey = expectFailure(
+      await runSdkExit(configDomain.getConfigKey("\uD800"), invalidHandler),
+    );
     const emptyTypedGetKey = expectFailure(
       await runSdkExit(
         configDomain.getConfigKeyWith("", configDomain.JsonValueSchema),
@@ -262,6 +265,7 @@ describe("supporting domain boundaries", () => {
     expect(cyclicConfig).toBeInstanceOf(PutioValidationError);
     expect(emptyGetKey).toBeInstanceOf(PutioValidationError);
     expect(dotGetKey).toBeInstanceOf(PutioValidationError);
+    expect(malformedGetKey).toBeInstanceOf(PutioValidationError);
     expect(emptyTypedGetKey).toBeInstanceOf(PutioValidationError);
     expect(invalidSetValue).toBeInstanceOf(PutioValidationError);
     expect(sparseSetValue).toBeInstanceOf(PutioValidationError);

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -1,5 +1,6 @@
 import { PutioOperationError, PutioValidationError } from "../core/errors.js";
 import { Effect, Schema } from "effect";
+import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vite-plus/test";
 
 import * as configDomain from "./config.js";
@@ -77,6 +78,8 @@ describe("supporting domain boundaries", () => {
     );
     expect(accessorExit._tag).toBe("Failure");
     expect(getterCalls).toBe(0);
+    const crossRealmConfig: unknown = runInNewContext(`({ locale: "en" })`);
+    expect(decodeJsonObject(crossRealmConfig)).toEqual({ locale: "en" });
     expect(() => decodeJsonObject(["nope"])).toThrow("Expected a JSON object");
 
     expect(

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -208,6 +208,9 @@ describe("supporting domain boundaries", () => {
         invalidHandler,
       ),
     );
+    const emptySetKey = expectFailure(
+      await runSdkExit(configDomain.setConfigKey("", "light"), invalidHandler),
+    );
     const emptyDeleteKey = expectFailure(
       await runSdkExit(configDomain.deleteConfigKey(""), invalidHandler),
     );
@@ -217,6 +220,7 @@ describe("supporting domain boundaries", () => {
     expect(emptyGetKey).toBeInstanceOf(PutioValidationError);
     expect(emptyTypedGetKey).toBeInstanceOf(PutioValidationError);
     expect(invalidSetValue).toBeInstanceOf(PutioValidationError);
+    expect(emptySetKey).toBeInstanceOf(PutioValidationError);
     expect(emptyDeleteKey).toBeInstanceOf(PutioValidationError);
     expect(requestCount).toBe(0);
   });

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -74,6 +74,29 @@ describe("supporting domain boundaries", () => {
     const sparseValue: Array<configDomain.PutioJsonValue> = [];
     sparseValue.length = 1;
     expect(() => decodeJsonValue(sparseValue)).toThrow("Expected a JSON-compatible value");
+    let lengthReads = 0;
+    const lengthSpoof = new Proxy([Number.NaN], {
+      get: (target, key, receiver) => {
+        if (key === "length") {
+          lengthReads += 1;
+          return 0;
+        }
+        return Reflect.get(target, key, receiver);
+      },
+    });
+    expect(() => decodeJsonValue(lengthSpoof)).toThrow("Expected a JSON-compatible value");
+    expect(lengthReads).toBe(0);
+    const customArrayPrototype = Object.create(Array.prototype);
+    const customPrototypeArray = ["sdk"];
+    Object.setPrototypeOf(customPrototypeArray, customArrayPrototype);
+    expect(() => decodeJsonValue(customPrototypeArray)).toThrow("Expected a JSON-compatible value");
+    const forgedArrayPrototype: Record<string, unknown> = Object.create(null);
+    Object.defineProperty(forgedArrayPrototype, "constructor", { value: Array });
+    const forgedPrototypeArray = ["sdk"];
+    Object.setPrototypeOf(forgedPrototypeArray, forgedArrayPrototype);
+    expect(() => decodeJsonValue(forgedPrototypeArray)).toThrow("Expected a JSON-compatible value");
+    const crossRealmArray: unknown = runInNewContext(`["sdk", 1, false]`);
+    expect(decodeJsonValue(crossRealmArray)).toEqual(["sdk", 1, false]);
     let getterCalls = 0;
     const accessorValue: configDomain.PutioJsonObject = {};
     Object.defineProperty(accessorValue, "count", {
@@ -345,6 +368,11 @@ describe("supporting domain boundaries", () => {
     Object.defineProperty(forgedPrototype, "constructor", { value: Object });
     const forgedValue: Record<string, unknown> = Object.create(forgedPrototype);
     forgedValue.enabled = true;
+    const lengthSpoof = new Proxy([Number.NaN], {
+      get: (target, key, receiver) => (key === "length" ? 0 : Reflect.get(target, key, receiver)),
+    });
+    const customPrototypeArray = ["sdk"];
+    Object.setPrototypeOf(customPrototypeArray, Object.create(Array.prototype));
     const invalidValues = [
       Number.NaN,
       Number.POSITIVE_INFINITY,
@@ -353,6 +381,8 @@ describe("supporting domain boundaries", () => {
       sparseValue,
       accessorValue,
       forgedValue,
+      lengthSpoof,
+      customPrototypeArray,
       new Date(),
     ];
     const failures = await Promise.all(

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -115,12 +115,19 @@ describe("supporting domain boundaries", () => {
       ),
     ).toEqual({ locale: "en" });
 
+    const configInput: configDomain.PutioJsonObject = { locale: "en" };
+    let descriptorWalks = 0;
+    const trackedConfig = new Proxy(configInput, {
+      ownKeys: (target) => {
+        descriptorWalks += 1;
+        return Reflect.ownKeys(target);
+      },
+    });
     expect(
       await runSdkEffect(
-        configDomain.writeConfig({
-          locale: "en",
-        }),
+        configDomain.writeConfig(trackedConfig),
         (request) => {
+          Object.defineProperty(configInput, "locale", { value: "tr" });
           expect(getJsonBody(request)).toEqual({
             config: {
               locale: "en",
@@ -131,6 +138,7 @@ describe("supporting domain boundaries", () => {
         { accessToken: "token-123" },
       ),
     ).toEqual({ status: "OK" });
+    expect(descriptorWalks).toBe(1);
 
     expect(
       await runSdkEffect(

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -1,4 +1,4 @@
-import { PutioOperationError } from "../core/errors.js";
+import { PutioOperationError, PutioValidationError } from "../core/errors.js";
 import { Schema } from "effect";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -52,6 +52,14 @@ describe("supporting domain boundaries", () => {
       nested: { enabled: true },
     });
     expect(() => decodeJsonValue(() => "nope")).toThrow("Expected a JSON-compatible value");
+    expect(() => decodeJsonValue(Number.NaN)).toThrow("Expected a JSON-compatible value");
+    expect(() => decodeJsonValue(Number.POSITIVE_INFINITY)).toThrow(
+      "Expected a JSON-compatible value",
+    );
+    expect(() => decodeJsonObject(new Date())).toThrow("Expected a JSON object");
+    const cyclicValue: { self?: unknown } = {};
+    cyclicValue.self = cyclicValue;
+    expect(() => decodeJsonValue(cyclicValue)).toThrow("Expected a JSON-compatible value");
     expect(() => decodeJsonObject(["nope"])).toThrow("Expected a JSON object");
 
     expect(
@@ -168,6 +176,49 @@ describe("supporting domain boundaries", () => {
         { accessToken: "token-123" },
       ),
     ).toEqual({ status: "OK" });
+
+    let requestCount = 0;
+    const invalidHandler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+    const invalidConfig = expectFailure(
+      await runSdkExit(configDomain.writeConfig({ count: Number.NaN }), invalidHandler),
+    );
+    const cyclicConfig = expectFailure(
+      await runSdkExit(
+        // @ts-expect-error JavaScript callers can supply cyclic objects.
+        configDomain.writeConfig(cyclicValue),
+        invalidHandler,
+      ),
+    );
+    const emptyGetKey = expectFailure(
+      await runSdkExit(configDomain.getConfigKey(""), invalidHandler),
+    );
+    const emptyTypedGetKey = expectFailure(
+      await runSdkExit(
+        configDomain.getConfigKeyWith("", configDomain.JsonValueSchema),
+        invalidHandler,
+      ),
+    );
+    const invalidSetValue = expectFailure(
+      await runSdkExit(
+        // @ts-expect-error JavaScript callers can supply non-JSON values.
+        configDomain.setConfigKey("theme", undefined),
+        invalidHandler,
+      ),
+    );
+    const emptyDeleteKey = expectFailure(
+      await runSdkExit(configDomain.deleteConfigKey(""), invalidHandler),
+    );
+
+    expect(invalidConfig).toBeInstanceOf(PutioValidationError);
+    expect(cyclicConfig).toBeInstanceOf(PutioValidationError);
+    expect(emptyGetKey).toBeInstanceOf(PutioValidationError);
+    expect(emptyTypedGetKey).toBeInstanceOf(PutioValidationError);
+    expect(invalidSetValue).toBeInstanceOf(PutioValidationError);
+    expect(emptyDeleteKey).toBeInstanceOf(PutioValidationError);
+    expect(requestCount).toBe(0);
   });
 
   it("covers download links and events", async () => {

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -80,6 +80,11 @@ describe("supporting domain boundaries", () => {
     expect(getterCalls).toBe(0);
     const crossRealmConfig: unknown = runInNewContext(`({ locale: "en" })`);
     expect(decodeJsonObject(crossRealmConfig)).toEqual({ locale: "en" });
+    const customPrototype: Record<string, unknown> = Object.create(null);
+    customPrototype.inherited = true;
+    const customPrototypeConfig: Record<string, unknown> = Object.create(customPrototype);
+    customPrototypeConfig.locale = "en";
+    expect(() => decodeJsonObject(customPrototypeConfig)).toThrow("Expected a JSON object");
     expect(() => decodeJsonObject(["nope"])).toThrow("Expected a JSON object");
 
     expect(

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -251,6 +251,11 @@ describe("supporting domain boundaries", () => {
         invalidHandler,
       ),
     );
+    const revokedConfig = Proxy.revocable<configDomain.PutioJsonObject>({}, {});
+    revokedConfig.revoke();
+    const revokedConfigFailure = expectFailure(
+      await runSdkExit(configDomain.writeConfig(revokedConfig.proxy), invalidHandler),
+    );
     const emptyGetKey = expectFailure(
       await runSdkExit(configDomain.getConfigKey(""), invalidHandler),
     );
@@ -270,6 +275,15 @@ describe("supporting domain boundaries", () => {
       await runSdkExit(
         // @ts-expect-error JavaScript callers can supply non-JSON values.
         configDomain.setConfigKey("theme", undefined),
+        invalidHandler,
+      ),
+    );
+    const fakeSecret = "sdk-fake-secret-for-redaction";
+    const sensitiveInvalidValue = { invalid: undefined, token: fakeSecret };
+    const sensitiveInvalidError = expectFailure(
+      await runSdkExit(
+        // @ts-expect-error JavaScript callers can supply objects containing non-JSON values.
+        configDomain.setConfigKey("credentials", sensitiveInvalidValue),
         invalidHandler,
       ),
     );
@@ -294,11 +308,14 @@ describe("supporting domain boundaries", () => {
 
     expect(invalidConfig).toBeInstanceOf(PutioValidationError);
     expect(cyclicConfig).toBeInstanceOf(PutioValidationError);
+    expect(revokedConfigFailure).toBeInstanceOf(PutioValidationError);
     expect(emptyGetKey).toBeInstanceOf(PutioValidationError);
     expect(dotGetKey).toBeInstanceOf(PutioValidationError);
     expect(malformedGetKey).toBeInstanceOf(PutioValidationError);
     expect(emptyTypedGetKey).toBeInstanceOf(PutioValidationError);
     expect(invalidSetValue).toBeInstanceOf(PutioValidationError);
+    expect(sensitiveInvalidError).toBeInstanceOf(PutioValidationError);
+    expect(String(sensitiveInvalidError.cause)).not.toContain(fakeSecret);
     expect(sparseSetValue).toBeInstanceOf(PutioValidationError);
     expect(accessorConfig).toBeInstanceOf(PutioValidationError);
     expect(emptySetKey).toBeInstanceOf(PutioValidationError);
@@ -341,6 +358,21 @@ describe("supporting domain boundaries", () => {
     expect(
       failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
     ).toBe(true);
+
+    let fullConfigRequestCount = 0;
+    const fullConfigFailure = expectFailure(
+      await runSdkExit(
+        configDomain.readConfig(),
+        () => {
+          fullConfigRequestCount += 1;
+          return inMemoryJsonResponse({ config: new Date(), status: "OK" });
+        },
+        { accessToken: "token-123" },
+      ),
+    );
+
+    expect(fullConfigFailure).toBeInstanceOf(PutioValidationError);
+    expect(fullConfigRequestCount).toBe(1);
   });
 
   it("covers download links and events", async () => {

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -1,5 +1,5 @@
 import { PutioOperationError, PutioValidationError } from "../core/errors.js";
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 import { describe, expect, it } from "vite-plus/test";
 
 import * as configDomain from "./config.js";
@@ -60,6 +60,23 @@ describe("supporting domain boundaries", () => {
     const cyclicValue: { self?: unknown } = {};
     cyclicValue.self = cyclicValue;
     expect(() => decodeJsonValue(cyclicValue)).toThrow("Expected a JSON-compatible value");
+    const sparseValue: Array<configDomain.PutioJsonValue> = [];
+    sparseValue.length = 1;
+    expect(() => decodeJsonValue(sparseValue)).toThrow("Expected a JSON-compatible value");
+    let getterCalls = 0;
+    const accessorValue: configDomain.PutioJsonObject = {};
+    Object.defineProperty(accessorValue, "count", {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1;
+        return 1;
+      },
+    });
+    const accessorExit = Effect.runSyncExit(
+      Schema.decodeUnknownEffect(configDomain.JsonObjectSchema)(accessorValue),
+    );
+    expect(accessorExit._tag).toBe("Failure");
+    expect(getterCalls).toBe(0);
     expect(() => decodeJsonObject(["nope"])).toThrow("Expected a JSON object");
 
     expect(
@@ -208,6 +225,12 @@ describe("supporting domain boundaries", () => {
         invalidHandler,
       ),
     );
+    const sparseSetValue = expectFailure(
+      await runSdkExit(configDomain.setConfigKey("sparse", sparseValue), invalidHandler),
+    );
+    const accessorConfig = expectFailure(
+      await runSdkExit(configDomain.writeConfig(accessorValue), invalidHandler),
+    );
     const emptySetKey = expectFailure(
       await runSdkExit(configDomain.setConfigKey("", "light"), invalidHandler),
     );
@@ -220,8 +243,11 @@ describe("supporting domain boundaries", () => {
     expect(emptyGetKey).toBeInstanceOf(PutioValidationError);
     expect(emptyTypedGetKey).toBeInstanceOf(PutioValidationError);
     expect(invalidSetValue).toBeInstanceOf(PutioValidationError);
+    expect(sparseSetValue).toBeInstanceOf(PutioValidationError);
+    expect(accessorConfig).toBeInstanceOf(PutioValidationError);
     expect(emptySetKey).toBeInstanceOf(PutioValidationError);
     expect(emptyDeleteKey).toBeInstanceOf(PutioValidationError);
+    expect(getterCalls).toBe(0);
     expect(requestCount).toBe(0);
   });
 

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -87,22 +87,24 @@ describe("supporting domain boundaries", () => {
     expect(() => decodeJsonObject(customPrototypeConfig)).toThrow("Expected a JSON object");
     expect(() => decodeJsonObject(["nope"])).toThrow("Expected a JSON object");
 
-    expect(
-      await runSdkEffect(
-        configDomain.readConfig(),
-        () =>
-          jsonResponse({
-            config: {
-              nested: {
-                enabled: true,
-              },
-              theme: "dark",
-            },
-            status: "OK",
-          }),
-        { accessToken: "token-123" },
-      ),
-    ).toEqual({
+    const responseConfig = {
+      nested: {
+        enabled: true,
+      },
+      theme: "dark",
+    };
+    const configResponse = new Response(null, {
+      headers: { "content-type": "application/json" },
+    });
+    Object.defineProperty(configResponse, "json", {
+      value: async () => ({ config: responseConfig, status: "OK" }),
+    });
+    const decodedConfig = await runSdkEffect(configDomain.readConfig(), () => configResponse, {
+      accessToken: "token-123",
+    });
+
+    expect(decodedConfig).toBe(responseConfig);
+    expect(decodedConfig).toEqual({
       nested: {
         enabled: true,
       },
@@ -158,6 +160,21 @@ describe("supporting domain boundaries", () => {
         { accessToken: "token-123" },
       ),
     ).toBe("dark");
+
+    const responseValue = { enabled: true };
+    const valueResponse = new Response(null, {
+      headers: { "content-type": "application/json" },
+    });
+    Object.defineProperty(valueResponse, "json", {
+      value: async () => ({ status: "OK", value: responseValue }),
+    });
+    const decodedValue = await runSdkEffect(
+      configDomain.getConfigKey("feature"),
+      () => valueResponse,
+      { accessToken: "token-123" },
+    );
+
+    expect(decodedValue).toBe(responseValue);
 
     expect(
       await runSdkEffect(


### PR DESCRIPTION
## Summary

Enforces true JSON/config-key validation before config-domain requests are serialized.

## Changed

- reject non-finite numbers, non-plain objects, and cyclic values from JSON schemas
- keep arrays, nested records, primitives, and shared acyclic values supported
- require non-empty config keys while retaining safe path-segment encoding
- decode full-config writes and key/value writes before transport
- map invalid runtime inputs to `PutioValidationError`
- assert invalid reads/writes/sets/deletes make zero requests

## Review aids

```text
unknown config value
  -> finite primitive | array | plain acyclic record
     -> JSON request
  -> otherwise PutioValidationError (no transport)

config key
  -> non-empty string -> encoded path segment
```

## Risks

Medium-low. Values that `JSON.stringify` would silently coerce (`NaN`, infinities, dates) or reject (cycles) now fail explicitly at the SDK boundary.

## Verification

- `pnpm exec vp run verify` (20 files / 97 tests plus coverage)
- `pnpm exec vp run lint:package`
- `pnpm exec vp run test:compat`

## Complexity

Medium: recursive JSON validation plus four request boundaries.

Part of #108.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict JSON and config-key validation to all config endpoints with a unified, realm‑safe JSON walker that snapshots requests and validates responses/envelopes using own property descriptors. Invalid inputs never hit the network, invalid responses raise `PutioValidationError`, and sensitive values are redacted; part of #108.

- **Bug Fixes**
  - Validate config keys (non-empty, not "."/"..", well-formed Unicode) for `writeConfig`, `getConfigKey`, `getConfigKeyWith`, `setConfigKey`, and `deleteConfigKey`; `setConfigKey` validates key+value together.
  - Snapshot request JSON via a single-pass, linear walker; accept cross‑realm native arrays/objects; reject `NaN`/`Infinity`, cycles, Dates, sparse arrays, spoofed `length`, custom‑prototype records/arrays.
  - Validate response envelopes/values via own descriptors only (no getters), closing accessor/prototype/length bypasses; preserve identity of decoded values.

- **Refactors**
  - Unified JSON walker powers both request snapshotting and response checks; keep snapshots realm‑safe and linear.
  - Reuse decoded snapshots and avoid cloning in typed reads and response decoding.

<sup>Written for commit be71d67dc8cc4cb72fc98cac921a342614299fe9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

