### PR TITLE
test(routes): add public matrix validator

### DIFF
--- a/scripts/route-matrix.mts
+++ b/scripts/route-matrix.mts
@@ -35,7 +35,7 @@ export class RouteMatrixValidationError extends Error {
   }
 }
 
-const canonicalPathPattern = /^\/v2(?:\/(?:[a-z0-9._~-]+|:[A-Za-z][A-Za-z0-9]*))*$/;
+const canonicalPathPattern = /^\/v2(?:\/(?:[a-z0-9._~-]+|:[A-Za-z][A-Za-z0-9]*))+(?:\/)?$/;
 const operationPattern = /^[a-z][A-Za-z0-9]*(?:\.[a-z][A-Za-z0-9]*)+$/;
 const sourcePattern = /^[A-Za-z0-9._/-]+\.py:[1-9][0-9]*$/;
 const followUpPattern =

--- a/scripts/route-matrix.mts
+++ b/scripts/route-matrix.mts
@@ -35,7 +35,8 @@ export class RouteMatrixValidationError extends Error {
   }
 }
 
-const canonicalPathPattern = /^\/v2(?:\/(?:[a-z0-9._~-]+|:[A-Za-z][A-Za-z0-9]*))+(?:\/)?$/;
+const canonicalPathPattern =
+  /^\/v2(?:\/(?!\.{1,2}(?:\/|$))(?:[a-z0-9._~-]+|:[A-Za-z][A-Za-z0-9]*))+(?:\/)?$/;
 const operationPattern = /^[a-z][A-Za-z0-9]*(?:\.[a-z][A-Za-z0-9]*)+$/;
 const sourcePattern = /^[A-Za-z0-9._/-]+\.py:[1-9][0-9]*$/;
 const followUpPattern =

--- a/scripts/route-matrix.mts
+++ b/scripts/route-matrix.mts
@@ -1,0 +1,154 @@
+import { Schema } from "effect";
+
+const RouteMethodSchema = Schema.Literals(["DELETE", "GET", "PATCH", "POST", "PUT"]);
+const RouteClassificationSchema = Schema.Literals(["equivalent", "excluded", "investigate", "sdk"]);
+
+const RouteDecisionSchema = Schema.Struct({
+  classification: RouteClassificationSchema,
+  followUp: Schema.optional(Schema.String),
+  method: RouteMethodSchema,
+  operation: Schema.optional(Schema.String),
+  path: Schema.String,
+  rationale: Schema.String,
+  source: Schema.String,
+});
+
+export const RouteMatrixSchema = Schema.Struct({
+  routes: Schema.Array(RouteDecisionSchema),
+  version: Schema.Literal(1),
+});
+
+export type RouteMatrix = Schema.Schema.Type<typeof RouteMatrixSchema>;
+
+export interface RouteMatrixClientSurfaces {
+  readonly effect: unknown;
+  readonly promise: unknown;
+}
+
+export class RouteMatrixValidationError extends Error {
+  readonly issues: ReadonlyArray<string>;
+
+  constructor(issues: ReadonlyArray<string>) {
+    super(`Route matrix validation failed:\n${issues.map((issue) => `- ${issue}`).join("\n")}`);
+    this.name = "RouteMatrixValidationError";
+    this.issues = issues;
+  }
+}
+
+const canonicalPathPattern = /^\/v2(?:\/(?:[a-z0-9._~-]+|:[A-Za-z][A-Za-z0-9]*))*$/;
+const operationPattern = /^[a-z][A-Za-z0-9]*(?:\.[a-z][A-Za-z0-9]*)+$/;
+const sourcePattern = /^[A-Za-z0-9._/-]+\.py:[1-9][0-9]*$/;
+const followUpPattern =
+  /^https:\/\/github\.com\/putdotio\/putio-sdk-typescript\/issues\/[1-9][0-9]*$/;
+const internalPrefixes = ["/v2/admin", "/v2/private"];
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null;
+
+const resolveOperation = (surface: unknown, operation: string): unknown => {
+  let current = surface;
+  for (const segment of operation.split(".")) {
+    if (!isRecord(current) || !Object.hasOwn(current, segment)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+};
+
+const validateClassification = (
+  route: RouteMatrix["routes"][number],
+  index: number,
+): ReadonlyArray<string> => {
+  const location = `routes[${index}] ${route.method} ${route.path}`;
+  const issues: Array<string> = [];
+
+  if (route.classification === "sdk" || route.classification === "equivalent") {
+    if (route.operation === undefined) {
+      issues.push(`${location}: ${route.classification} routes require an operation`);
+    }
+  } else if (route.operation !== undefined) {
+    issues.push(`${location}: ${route.classification} routes cannot declare an operation`);
+  }
+
+  if (route.classification === "investigate") {
+    if (route.followUp === undefined || !followUpPattern.test(route.followUp)) {
+      issues.push(`${location}: investigate routes require a repository issue URL`);
+    }
+  } else if (route.followUp !== undefined) {
+    issues.push(`${location}: only investigate routes can declare followUp`);
+  }
+
+  return issues;
+};
+
+export const validateRouteMatrix = (
+  input: unknown,
+  clients: RouteMatrixClientSurfaces,
+): RouteMatrix => {
+  let matrix: RouteMatrix;
+  try {
+    matrix = Schema.decodeUnknownSync(RouteMatrixSchema, {
+      errors: "all",
+      onExcessProperty: "error",
+    })(input);
+  } catch (cause) {
+    throw new RouteMatrixValidationError([`schema: ${String(cause)}`]);
+  }
+
+  const issues: Array<string> = [];
+  const routes = new Set<string>();
+
+  for (const [index, route] of matrix.routes.entries()) {
+    const location = `routes[${index}] ${route.method} ${route.path}`;
+    const key = `${route.method} ${route.path}`;
+
+    if (routes.has(key)) {
+      issues.push(`${location}: duplicate route`);
+    }
+    routes.add(key);
+
+    if (!canonicalPathPattern.test(route.path)) {
+      issues.push(`${location}: path must be a canonical /v2 path`);
+    }
+    if (
+      internalPrefixes.some(
+        (prefix) => route.path === prefix || route.path.startsWith(`${prefix}/`),
+      )
+    ) {
+      issues.push(`${location}: internal routes do not belong in the public matrix`);
+    }
+    if (route.rationale.trim().length === 0) {
+      issues.push(`${location}: rationale must not be empty`);
+    }
+    if (
+      !sourcePattern.test(route.source) ||
+      route.source.startsWith("/") ||
+      route.source.includes("..") ||
+      route.source.includes("\\")
+    ) {
+      issues.push(`${location}: source must be a backend-relative Python file and line`);
+    }
+
+    issues.push(...validateClassification(route, index));
+
+    if (route.operation !== undefined) {
+      if (!operationPattern.test(route.operation)) {
+        issues.push(`${location}: operation must be a dotted client method path`);
+      } else {
+        if (typeof resolveOperation(clients.effect, route.operation) !== "function") {
+          issues.push(`${location}: Effect client is missing ${route.operation}`);
+        }
+        if (typeof resolveOperation(clients.promise, route.operation) !== "function") {
+          issues.push(`${location}: Promise client is missing ${route.operation}`);
+        }
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    throw new RouteMatrixValidationError(issues);
+  }
+
+  return matrix;
+};

--- a/scripts/route-matrix.mts
+++ b/scripts/route-matrix.mts
@@ -133,7 +133,10 @@ export const validateRouteMatrix = (
 
     issues.push(...validateClassification(route, index));
 
-    if (route.operation !== undefined) {
+    if (
+      route.operation !== undefined &&
+      (route.classification === "sdk" || route.classification === "equivalent")
+    ) {
       if (!operationPattern.test(route.operation)) {
         issues.push(`${location}: operation must be a dotted client method path`);
       } else {

--- a/scripts/route-matrix.spec.ts
+++ b/scripts/route-matrix.spec.ts
@@ -146,6 +146,31 @@ describe("route matrix validation", () => {
     );
   });
 
+  it("does not validate forbidden operations against client surfaces", () => {
+    const invalid = {
+      routes: [
+        {
+          ...validMatrix.routes[2],
+          operation: "files.missing",
+        },
+      ],
+      version: 1,
+    };
+
+    try {
+      validateRouteMatrix(invalid, clients);
+      throw new Error("Expected route matrix validation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RouteMatrixValidationError);
+      if (!(error instanceof RouteMatrixValidationError)) {
+        throw error;
+      }
+      expect(error.issues).toEqual([
+        "routes[0] GET /v2/docs: excluded routes cannot declare an operation",
+      ]);
+    }
+  });
+
   it("rejects unknown fields instead of silently dropping typos", () => {
     const invalid = {
       ...validMatrix,

--- a/scripts/route-matrix.spec.ts
+++ b/scripts/route-matrix.spec.ts
@@ -7,6 +7,9 @@ const clients = {
     account: {
       getInfo: () => undefined,
     },
+    auth: {
+      grants: () => undefined,
+    },
     files: {
       copy: () => undefined,
       get: () => undefined,
@@ -15,6 +18,9 @@ const clients = {
   promise: {
     account: {
       getInfo: () => undefined,
+    },
+    auth: {
+      grants: () => undefined,
     },
     files: {
       copy: () => undefined,
@@ -49,6 +55,14 @@ const validMatrix = {
       source: "putio/api2/documentation.py:6",
     },
     {
+      classification: "sdk",
+      method: "GET",
+      operation: "auth.grants",
+      path: "/v2/oauth/grants/",
+      rationale: "The trailing slash is part of the registered blueprint-root route.",
+      source: "putio/api2/oauth_grants.py:28",
+    },
+    {
       classification: "investigate",
       followUp: "https://github.com/putdotio/putio-sdk-typescript/issues/108",
       method: "POST",
@@ -77,6 +91,13 @@ describe("route matrix validation", () => {
           rationale: " ",
           source: "/Users/maintainer/putio/api2/admin.py:1",
         },
+        {
+          classification: "excluded",
+          method: "GET",
+          path: "/v2/",
+          rationale: "A bare API prefix is not a public operation.",
+          source: "putio/app.py:1",
+        },
       ],
       version: 1,
     };
@@ -101,7 +122,7 @@ describe("route matrix validation", () => {
           operation: "files.get",
         },
         {
-          ...validMatrix.routes[3],
+          ...validMatrix.routes[4],
           followUp: "https://github.com/putdotio/other/issues/1",
         },
       ],

--- a/scripts/route-matrix.spec.ts
+++ b/scripts/route-matrix.spec.ts
@@ -98,6 +98,13 @@ describe("route matrix validation", () => {
           rationale: "A bare API prefix is not a public operation.",
           source: "putio/app.py:1",
         },
+        {
+          classification: "excluded",
+          method: "GET",
+          path: "/v2/files/../admin/users",
+          rationale: "Dot navigation cannot turn a public-looking path into an internal route.",
+          source: "putio/api2/files.py:1",
+        },
       ],
       version: 1,
     };

--- a/scripts/route-matrix.spec.ts
+++ b/scripts/route-matrix.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { RouteMatrixValidationError, validateRouteMatrix } from "./route-matrix.mts";
+
+const clients = {
+  effect: {
+    account: {
+      getInfo: () => undefined,
+    },
+    files: {
+      copy: () => undefined,
+      get: () => undefined,
+    },
+  },
+  promise: {
+    account: {
+      getInfo: () => undefined,
+    },
+    files: {
+      copy: () => undefined,
+      get: () => undefined,
+    },
+  },
+};
+
+const validMatrix = {
+  routes: [
+    {
+      classification: "sdk",
+      method: "GET",
+      operation: "account.getInfo",
+      path: "/v2/account/info",
+      rationale: "The SDK exposes the backend account-info contract directly.",
+      source: "putio/api2/account.py:137",
+    },
+    {
+      classification: "equivalent",
+      method: "GET",
+      operation: "files.get",
+      path: "/v2/files/:fileId",
+      rationale: "The client method uses an input object while preserving the route contract.",
+      source: "putio/api2/files.py:832",
+    },
+    {
+      classification: "excluded",
+      method: "GET",
+      path: "/v2/docs",
+      rationale: "Interactive backend documentation is not an SDK operation.",
+      source: "putio/api2/documentation.py:6",
+    },
+    {
+      classification: "investigate",
+      followUp: "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      method: "POST",
+      path: "/v2/files/copy",
+      rationale: "The public contract still needs an explicit SDK disposition.",
+      source: "putio/api2/files.py:1381",
+    },
+  ],
+  version: 1,
+} as const;
+
+describe("route matrix validation", () => {
+  it("accepts every supported classification", () => {
+    expect(validateRouteMatrix(validMatrix, clients)).toEqual(validMatrix);
+  });
+
+  it("rejects malformed, duplicate, internal, and absolute route evidence", () => {
+    const invalid = {
+      routes: [
+        validMatrix.routes[0],
+        validMatrix.routes[0],
+        {
+          classification: "excluded",
+          method: "GET",
+          path: "/v2/admin/users/<id>",
+          rationale: " ",
+          source: "/Users/maintainer/putio/api2/admin.py:1",
+        },
+      ],
+      version: 1,
+    };
+
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(RouteMatrixValidationError);
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(/duplicate route/);
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(/canonical \/v2 path/);
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(/internal routes/);
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(/rationale must not be empty/);
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(/backend-relative/);
+  });
+
+  it("rejects invalid classification fields and missing client methods", () => {
+    const invalid = {
+      routes: [
+        {
+          ...validMatrix.routes[0],
+          operation: "account.missing",
+        },
+        {
+          ...validMatrix.routes[2],
+          operation: "files.get",
+        },
+        {
+          ...validMatrix.routes[3],
+          followUp: "https://github.com/putdotio/other/issues/1",
+        },
+      ],
+      version: 1,
+    };
+
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(/Effect client is missing/);
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(/Promise client is missing/);
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(
+      /excluded routes cannot declare an operation/,
+    );
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(
+      /investigate routes require a repository issue URL/,
+    );
+  });
+
+  it("rejects unknown fields instead of silently dropping typos", () => {
+    const invalid = {
+      ...validMatrix,
+      routes: [
+        {
+          ...validMatrix.routes[0],
+          operations: "account.getInfo",
+        },
+      ],
+    };
+
+    expect(() => validateRouteMatrix(invalid, clients)).toThrow(/operations/);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,6 @@ export default defineConfig({
   test: {
     coverage: coverageConfig,
     exclude: [".repos/**", "test/live/**"],
-    include: ["src/**/*.spec.ts", "src/**/*.test.ts"],
+    include: ["scripts/**/*.spec.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Add the reusable validator for the public API route matrix tracked by #108.

## Changed

- decode the matrix with strict Effect schemas
- reject duplicate or malformed routes, internal prefixes, empty rationales, absolute backend evidence, and invalid classification fields
- verify every named operation exists on both Effect and Promise client surfaces
- run four deterministic validator cases through the default Vite+ test suite

## Review aids

Example supported mapping:

```text
GET /v2/account/info
  classification: sdk
  operation: account.getInfo
  required on: Effect client + Promise client
```

Invalid entries produce one collected error list rather than failing at the first route.

## Risks

Low. This PR adds validation infrastructure only and does not change SDK runtime behavior.

## Verification

- `vp check .`
- `vp run test`
- `vp pack`
- top-of-stack `vp run verify`
- top-of-stack `vp run lint:package`
- top-of-stack `vp run test:compat`

## Complexity

Validation is linear in route count, with bounded dotted-operation traversal.