### PR TITLE
ci(routes): validate audited public decisions

### DIFF
--- a/docs/READINESS.md
+++ b/docs/READINESS.md
@@ -1,6 +1,6 @@
 # SDK Readiness
 
-This document answers one question: how ready is `@putdotio/sdk` by domain right now?
+This document records the current verification program for `@putdotio/sdk`.
 
 Readiness here is based on four things:
 
@@ -11,10 +11,21 @@ Readiness here is based on four things:
 
 ## Overall Status
 
-- namespace coverage is effectively complete for the current planned public domains
+- domain namespace coverage is broad, but endpoint completeness is not yet established
 - unit verification now covers all production code under `src/**` with a global 90% coverage guardrail
 - live coverage exists for every implemented domain
-- the main remaining work is depth of verification, not breadth of implementation
+- the route audit has confirmed both missing operations and contract drift
+
+## Public Route Matrix
+
+[`api-route-matrix.json`](./api-route-matrix.json) records method-level backend evidence and one
+of four decisions for each audited public route: `sdk`, `equivalent`, `excluded`, or
+`investigate`. `vp run verify` validates its shape, rejects internal or duplicate routes, and
+checks every named operation on both Effect and Promise clients.
+
+The matrix is currently an audited seed, not a completeness claim. Its `investigate` entries are
+linked to the endpoint-parity epic and do not count as supported. Endpoint completeness requires a
+full backend comparison and zero unresolved `investigate` entries.
 
 ## Last Full Sweep
 

--- a/docs/api-route-matrix.json
+++ b/docs/api-route-matrix.json
@@ -1,0 +1,205 @@
+{
+  "routes": [
+    {
+      "classification": "sdk",
+      "method": "POST",
+      "operation": "account.clear",
+      "path": "/v2/account/clear",
+      "rationale": "The account client exposes the backend clear operation directly.",
+      "source": "putio/api2/account.py:350"
+    },
+    {
+      "classification": "sdk",
+      "method": "GET",
+      "operation": "account.listConfirmations",
+      "path": "/v2/account/confirmation/list",
+      "rationale": "The account client exposes confirmation listing directly.",
+      "source": "putio/api2/account.py:409"
+    },
+    {
+      "classification": "sdk",
+      "method": "POST",
+      "operation": "account.destroy",
+      "path": "/v2/account/destroy",
+      "rationale": "The account client exposes the destructive account operation directly.",
+      "source": "putio/api2/account.py:300"
+    },
+    {
+      "classification": "sdk",
+      "method": "GET",
+      "operation": "account.getInfo",
+      "path": "/v2/account/info",
+      "rationale": "The account client exposes the conditional account-info contract directly.",
+      "source": "putio/api2/account.py:137"
+    },
+    {
+      "classification": "sdk",
+      "method": "GET",
+      "operation": "account.getSettings",
+      "path": "/v2/account/settings",
+      "rationale": "The account client exposes account settings retrieval directly.",
+      "source": "putio/api2/account.py:179"
+    },
+    {
+      "classification": "sdk",
+      "method": "POST",
+      "operation": "account.saveSettings",
+      "path": "/v2/account/settings",
+      "rationale": "The account client exposes JSON settings updates directly.",
+      "source": "putio/api2/account.py:188"
+    },
+    {
+      "classification": "sdk",
+      "method": "GET",
+      "operation": "account.listSubtitleLanguages",
+      "path": "/v2/account/subtitle_languages",
+      "rationale": "The account client exposes the backend subtitle-language list directly.",
+      "source": "putio/api2/account.py:425"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/app_specific_password/:passwordId/delete",
+      "rationale": "The audited endpoint implementation is in the app-password stack and is not on this branch yet.",
+      "source": "putio/login/app_specific_password/api.py:92"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/app_specific_password/create",
+      "rationale": "The audited endpoint implementation is in the app-password stack and is not on this branch yet.",
+      "source": "putio/login/app_specific_password/api.py:34"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/app_specific_password/delete_all",
+      "rationale": "The audited endpoint implementation is in the app-password stack and is not on this branch yet.",
+      "source": "putio/login/app_specific_password/api.py:112"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "GET",
+      "path": "/v2/app_specific_password/list",
+      "rationale": "The audited endpoint implementation is in the app-password stack and is not on this branch yet.",
+      "source": "putio/login/app_specific_password/api.py:78"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "GET",
+      "path": "/v2/files/:fileId/can-write",
+      "rationale": "The audit confirmed a public route but has not yet selected SDK support or exclusion.",
+      "source": "putio/api2/files.py:2175"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "GET",
+      "path": "/v2/files/:parentId/child",
+      "rationale": "The audit confirmed a public route but has not yet selected SDK support or exclusion.",
+      "source": "putio/api2/files.py:786"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/files/:fileId/start-from",
+      "rationale": "The canonical playback operation is implemented in the contract stack and is not on this branch yet.",
+      "source": "putio/api2/files.py:2090"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/files/:fileId/start-from/delete",
+      "rationale": "The canonical playback reset is implemented in the contract stack and is not on this branch yet.",
+      "source": "putio/api2/files.py:2132"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/files/copy",
+      "rationale": "The audit confirmed a public route but has not yet selected SDK support or exclusion.",
+      "source": "putio/api2/files.py:1381"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/files/remove-sort-by-settings",
+      "rationale": "The audited endpoint implementation is in the file-sort stack and is not on this branch yet.",
+      "source": "putio/api2/files.py:707"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/files/set-sort-by",
+      "rationale": "The audited endpoint implementation is in the file-sort stack and is not on this branch yet.",
+      "source": "putio/api2/files.py:678"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/files/touch",
+      "rationale": "The audit confirmed a public route but has not yet selected SDK support or exclusion.",
+      "source": "putio/api2/files.py:1222"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "GET",
+      "path": "/v2/oauth2/access_token",
+      "rationale": "Authorization-code exchange needs a public SDK design and explicit credential-handling contract.",
+      "source": "putio/oauth/blueprints/api.py:190"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/oauth2/access_token",
+      "rationale": "Authorization-code exchange needs a public SDK design and explicit credential-handling contract.",
+      "source": "putio/oauth/blueprints/api.py:190"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "GET",
+      "path": "/v2/podcast/links",
+      "rationale": "The audited endpoint implementation is in the podcast stack and is not on this branch yet.",
+      "source": "putio/podcast/api.py:19"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/transfers/add-trackers/:transferId",
+      "rationale": "The audit confirmed a public route but has not yet selected SDK support or exclusion.",
+      "source": "putio/api2/transfers.py:813"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "GET",
+      "path": "/v2/transfers/:transferId/torrent",
+      "rationale": "The audit confirmed a public route but has not yet selected SDK support or exclusion.",
+      "source": "putio/api2/transfers.py:344"
+    },
+    {
+      "classification": "investigate",
+      "followUp": "https://github.com/putdotio/putio-sdk-typescript/issues/108",
+      "method": "POST",
+      "path": "/v2/transfers/remove",
+      "rationale": "The audit confirmed a public route but has not yet selected SDK support or exclusion.",
+      "source": "putio/api2/transfers.py:669"
+    }
+  ],
+  "version": 1
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "test:compat:bun": "node ./scripts/test-compat-bun.mts",
     "test:compat:node": "node ./scripts/test-compat-node.mts",
     "test:live": "vp pack && vp test run --config vitest.live.config.ts",
-    "verify": "vp check . && vp pack && knip && knip --production --no-gitignore && vp test run --coverage --passWithNoTests"
+    "validate:routes": "node ./scripts/validate-route-matrix.mts",
+    "verify": "vp check . && vp pack && knip && knip --production --no-gitignore && vp run validate:routes && vp test run --coverage --passWithNoTests"
   },
   "dependencies": {
     "effect": "4.0.0-beta.101"

--- a/package.json
+++ b/package.json
@@ -57,8 +57,9 @@
     "test:compat:bun": "node ./scripts/test-compat-bun.mts",
     "test:compat:node": "node ./scripts/test-compat-node.mts",
     "test:live": "vp pack && vp test run --config vitest.live.config.ts",
-    "validate:routes": "node ./scripts/validate-route-matrix.mts",
-    "verify": "vp check . && vp pack && knip && knip --production --no-gitignore && vp run validate:routes && vp test run --coverage --passWithNoTests"
+    "validate:routes": "vp pack && vp run validate:routes:packed",
+    "validate:routes:packed": "node ./scripts/validate-route-matrix.mts",
+    "verify": "vp check . && vp pack && knip && knip --production --no-gitignore && vp run validate:routes:packed && vp test run --coverage --passWithNoTests"
   },
   "dependencies": {
     "effect": "4.0.0-beta.101"

--- a/scripts/validate-route-matrix.mts
+++ b/scripts/validate-route-matrix.mts
@@ -8,6 +8,8 @@ const { createPutioSdkEffectClient, createPutioSdkPromiseClient } =
   await import("../dist/index.js");
 
 const promiseClient = createPutioSdkPromiseClient();
+let failed = false;
+let failure: unknown;
 
 try {
   const matrix = validateRouteMatrix(input, {
@@ -20,6 +22,20 @@ try {
   console.log(
     `Validated ${matrix.routes.length} public route decisions (${investigateCount} awaiting disposition).`,
   );
-} finally {
+} catch (error) {
+  failed = true;
+  failure = error;
+}
+
+try {
   await promiseClient.dispose();
+} catch (error) {
+  if (!failed) {
+    failed = true;
+    failure = error;
+  }
+}
+
+if (failed) {
+  throw failure;
 }

--- a/scripts/validate-route-matrix.mts
+++ b/scripts/validate-route-matrix.mts
@@ -1,0 +1,25 @@
+import { readFile } from "node:fs/promises";
+
+import { validateRouteMatrix } from "./route-matrix.mts";
+
+const matrixUrl = new URL("../docs/api-route-matrix.json", import.meta.url);
+const input: unknown = JSON.parse(await readFile(matrixUrl, "utf8"));
+const { createPutioSdkEffectClient, createPutioSdkPromiseClient } =
+  await import("../dist/index.js");
+
+const promiseClient = createPutioSdkPromiseClient();
+
+try {
+  const matrix = validateRouteMatrix(input, {
+    effect: createPutioSdkEffectClient(),
+    promise: promiseClient,
+  });
+  const investigateCount = matrix.routes.filter(
+    (route) => route.classification === "investigate",
+  ).length;
+  console.log(
+    `Validated ${matrix.routes.length} public route decisions (${investigateCount} awaiting disposition).`,
+  );
+} finally {
+  await promiseClient.dispose();
+}


### PR DESCRIPTION
## Summary

Seed the executable public route matrix for #108 and make it a blocking verification gate.

## Changed

- record 25 audited method-level decisions with backend-relative source evidence
- mark 18 unresolved routes as `investigate` and link them to the epic
- run matrix validation after the package build in `vp run verify`
- correct readiness language so domain breadth is not presented as endpoint completeness

## Review aids

```text
25 audited route decisions
  7 sdk
  18 investigate
  0 claimed equivalent/excluded
```

The seed explicitly includes every known candidate from the audit plus app-password, podcast, file-sort, and canonical playback routes already implemented in sibling stacks.

## Risks

The matrix is intentionally incomplete and says so in readiness documentation. It must not be interpreted as an endpoint-completeness claim until backend comparison is complete and the investigate count reaches zero.

## Verification

- `vp run verify` — 25 decisions validated; 18 awaiting disposition
- `vp run lint:package`
- `vp run test:compat` — Node, Chromium, Firefox, WebKit, and Bun

## Complexity

The added gate is linear in the number of recorded routes and runs against the already packed artifact.