### PR TITLE
fix(oauth): validate app requests before transport

### DIFF
--- a/src/domains/oauth.ts
+++ b/src/domains/oauth.ts
@@ -9,6 +9,7 @@ import {
   type PutioQueryValue,
 } from "../core/http.js";
 import {
+  mapDecodeErrorToValidationError,
   definePutioOperationErrorSpec,
   withOperationErrors,
   type PutioOperationFailure,
@@ -74,21 +75,24 @@ const OAuthRegeneratedTokenEnvelopeSchema = Schema.Struct({
   access_token: Schema.String,
   status: Schema.Literal("OK"),
 });
+const OAuthAppIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
+const OAuthAppDescriptionSchema = Schema.String.check(Schema.isMinLength(10));
+const OAuthAppUrlSchema = Schema.String.check(Schema.isMaxLength(255));
 export const OAuthAppCreateInputSchema = Schema.Struct({
-  callback: Schema.String,
-  description: Schema.String,
+  callback: OAuthAppUrlSchema,
+  description: OAuthAppDescriptionSchema,
   hidden: Schema.optional(Schema.Boolean),
   icon: Schema.optional(Schema.instanceOf(Blob)),
-  name: Schema.String,
-  website: Schema.String,
+  name: Schema.String.check(Schema.isMinLength(5)),
+  website: OAuthAppUrlSchema,
 });
 export const OAuthAppUpdateInputSchema = Schema.Struct({
-  callback: Schema.String,
-  description: Schema.String,
+  callback: OAuthAppUrlSchema,
+  description: OAuthAppDescriptionSchema,
   hidden: Schema.optional(Schema.Boolean),
   icon: Schema.optional(Schema.instanceOf(Blob)),
-  id: Schema.Int,
-  website: Schema.String,
+  id: OAuthAppIdSchema,
+  website: OAuthAppUrlSchema,
 });
 export const OAuthSetIconInputSchema = Schema.Struct({
   icon: Schema.instanceOf(Blob),
@@ -208,26 +212,47 @@ export const getOAuthApp = (
   GetOAuthAppError,
   PutioSdkContext
 > =>
-  requestJson(OAuthAppWithTokenSchema, {
-    method: "GET",
-    path: options?.edit
-      ? `/v2/oauth/apps/${encodePathSegment(id)}/edit`
-      : `/v2/oauth/apps/${encodePathSegment(id)}`,
-  }).pipe(withOperationErrors(GetOAuthAppErrorSpec));
+  Schema.decodeUnknownEffect(
+    Schema.Struct({
+      edit: Schema.optional(Schema.Boolean),
+      id: OAuthAppIdSchema,
+    }),
+  )({ edit: options?.edit, id }).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(OAuthAppWithTokenSchema, {
+        method: "GET",
+        path: decodedInput.edit
+          ? `/v2/oauth/apps/${encodePathSegment(decodedInput.id)}/edit`
+          : `/v2/oauth/apps/${encodePathSegment(decodedInput.id)}`,
+      }),
+    ),
+    withOperationErrors(GetOAuthAppErrorSpec),
+  );
 export const setOAuthAppIcon = (
   id: number,
   input: OAuthSetIconInput,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> => {
-  const formData = new FormData();
-  formData.append("icon", input.icon);
-  return requestJson(OkResponseSchema, {
-    body: {
-      type: "form-data",
-      value: formData,
-    },
-    method: "POST",
-    path: `/v2/oauth/apps/${encodePathSegment(id)}/icon`,
-  });
+  return Schema.decodeUnknownEffect(
+    Schema.Struct({
+      id: OAuthAppIdSchema,
+      input: OAuthSetIconInputSchema,
+    }),
+  )({ id, input }).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) => {
+      const formData = new FormData();
+      formData.append("icon", decodedInput.input.icon);
+      return requestJson(OkResponseSchema, {
+        body: {
+          type: "form-data",
+          value: formData,
+        },
+        method: "POST",
+        path: `/v2/oauth/apps/${encodePathSegment(decodedInput.id)}/icon`,
+      });
+    }),
+  );
 };
 export const createOAuthApp = (
   input: OAuthAppCreateInput,
@@ -236,14 +261,20 @@ export const createOAuthApp = (
   CreateOAuthAppError,
   PutioSdkContext
 > =>
-  requestJson(OAuthAppEnvelopeSchema, {
-    body: {
-      type: "form-data",
-      value: makeCreateOAuthAppFormData(input),
-    },
-    method: "POST",
-    path: "/v2/oauth/apps/register",
-  }).pipe(withOperationErrors(CreateOAuthAppErrorSpec));
+  Schema.decodeUnknownEffect(OAuthAppCreateInputSchema)(input).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(OAuthAppEnvelopeSchema, {
+        body: {
+          type: "form-data",
+          value: makeCreateOAuthAppFormData(decodedInput),
+        },
+        method: "POST",
+        path: "/v2/oauth/apps/register",
+      }),
+    ),
+    withOperationErrors(CreateOAuthAppErrorSpec),
+  );
 export const updateOAuthApp = (
   input: OAuthAppUpdateInput,
 ): Effect.Effect<
@@ -251,14 +282,20 @@ export const updateOAuthApp = (
   UpdateOAuthAppError,
   PutioSdkContext
 > =>
-  requestJson(OAuthAppWithTokenSchema, {
-    body: {
-      type: "form-data",
-      value: makeUpdateOAuthAppFormData(input),
-    },
-    method: "POST",
-    path: `/v2/oauth/apps/${encodePathSegment(input.id)}`,
-  }).pipe(withOperationErrors(UpdateOAuthAppErrorSpec));
+  Schema.decodeUnknownEffect(OAuthAppUpdateInputSchema)(input).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(OAuthAppWithTokenSchema, {
+        body: {
+          type: "form-data",
+          value: makeUpdateOAuthAppFormData(decodedInput),
+        },
+        method: "POST",
+        path: `/v2/oauth/apps/${encodePathSegment(decodedInput.id)}`,
+      }),
+    ),
+    withOperationErrors(UpdateOAuthAppErrorSpec),
+  );
 export const deleteOAuthApp = (
   id: number,
 ): Effect.Effect<
@@ -266,17 +303,30 @@ export const deleteOAuthApp = (
   DeleteOAuthAppError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/oauth/apps/${encodePathSegment(id)}/delete`,
-  }).pipe(withOperationErrors(DeleteOAuthAppErrorSpec));
+  Schema.decodeUnknownEffect(OAuthAppIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/oauth/apps/${encodePathSegment(decodedId)}/delete`,
+      }),
+    ),
+    withOperationErrors(DeleteOAuthAppErrorSpec),
+  );
 export const regenerateOAuthAppToken = (
   id: number,
 ): Effect.Effect<string, RegenerateOAuthAppTokenError, PutioSdkContext> =>
-  requestJson(OAuthRegeneratedTokenEnvelopeSchema, {
-    method: "POST",
-    path: `/v2/oauth/apps/${encodePathSegment(id)}/regenerate_token`,
-  }).pipe(selectJsonField("access_token"), withOperationErrors(RegenerateOAuthAppTokenErrorSpec));
+  Schema.decodeUnknownEffect(OAuthAppIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(OAuthRegeneratedTokenEnvelopeSchema, {
+        method: "POST",
+        path: `/v2/oauth/apps/${encodePathSegment(decodedId)}/regenerate_token`,
+      }),
+    ),
+    selectJsonField("access_token"),
+    withOperationErrors(RegenerateOAuthAppTokenErrorSpec),
+  );
 export const getPopularOAuthApps = (): Effect.Effect<
   ReadonlyArray<PopularOAuthApp>,
   PutioSdkError,

--- a/src/domains/ops.spec.ts
+++ b/src/domains/ops.spec.ts
@@ -274,7 +274,7 @@ describe("operational domain boundaries", () => {
       await runSdkEffect(
         oauth.createOAuthApp({
           callback: "https://example.com/callback",
-          description: "SDK app",
+          description: "SDK app test",
           hidden: true,
           icon: new Blob(["icon"], { type: "image/png" }),
           name: "SDK app",
@@ -365,6 +365,58 @@ describe("operational domain boundaries", () => {
     await runSdkEffect(oauth.deleteOAuthApp(9), () => jsonResponse({ status: "OK" }), {
       accessToken: "token-123",
     });
+  });
+
+  it("rejects invalid oauth app inputs before transport", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+    const validCreateInput = {
+      callback: "https://example.com/callback",
+      description: "A valid SDK application",
+      name: "SDK app",
+      website: "https://example.com",
+    };
+
+    const failures = await Promise.all([
+      runSdkExit(oauth.getOAuthApp(0), handler),
+      runSdkExit(
+        // @ts-expect-error JavaScript callers can provide invalid option values.
+        oauth.getOAuthApp(1, { edit: "yes" }),
+        handler,
+      ),
+      runSdkExit(
+        oauth.setOAuthAppIcon(0, { icon: new Blob(["icon"], { type: "image/png" }) }),
+        handler,
+      ),
+      runSdkExit(
+        // @ts-expect-error JavaScript callers can provide non-Blob icon values.
+        oauth.setOAuthAppIcon(1, { icon: "icon" }),
+        handler,
+      ),
+      runSdkExit(oauth.createOAuthApp({ ...validCreateInput, name: "app" }), handler),
+      runSdkExit(oauth.createOAuthApp({ ...validCreateInput, description: "too short" }), handler),
+      runSdkExit(oauth.createOAuthApp({ ...validCreateInput, website: "x".repeat(256) }), handler),
+      runSdkExit(oauth.createOAuthApp({ ...validCreateInput, callback: "x".repeat(256) }), handler),
+      runSdkExit(
+        oauth.updateOAuthApp({
+          callback: validCreateInput.callback,
+          description: "too short",
+          id: 1,
+          website: validCreateInput.website,
+        }),
+        handler,
+      ),
+      runSdkExit(oauth.deleteOAuthApp(0), handler),
+      runSdkExit(oauth.regenerateOAuthAppToken(0), handler),
+    ]);
+
+    expect(
+      failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
+    expect(requestCount).toBe(0);
   });
 
   it("covers sharing endpoints", async () => {


### PR DESCRIPTION
## Summary

Makes the existing OAuth-app request schemas real outbound boundaries instead of TypeScript-only declarations.

## Changed

- Decodes create and update payloads before constructing multipart form data.
- Decodes icon payloads, app IDs, and the get-operation edit flag before path construction.
- Aligns request constraints with the API contract: application names require at least 5 characters, descriptions at least 10, callback and website values at most 255, and app IDs must be positive integers.
- Maps invalid JavaScript inputs to `PutioValidationError` without issuing a request.
- Leaves response schemas and URL-builder helpers unchanged.

## Review aids

| SDK operations | Boundary proof |
| --- | --- |
| `oauth.create`, `oauth.update` | Decode the exported input schema before FormData construction |
| `oauth.setIcon` | Require a positive app ID and a real `Blob` before FormData construction |
| `oauth.get` | Require a positive app ID and a boolean optional edit flag before path construction |
| `oauth.delete`, `oauth.regenerateToken` | Require a positive app ID before path construction |

The regression test submits eleven invalid runtime inputs—including TypeScript-valid strings that violate API bounds and JavaScript-only wrong types—and asserts every failure is `PutioValidationError` with zero transport calls.

## Risks

- This tightens client-side acceptance only for values the API already rejects; valid wire formats and response decoding are unchanged.
- Multipart bodies are still built with the existing helpers after successful decoding.
- Pure URL builders remain synchronous and outside this outbound-request boundary slice.

## Verification

- `pnpm exec vp run verify`
- `pnpm exec vp run lint:package`
- `pnpm exec vp run test:compat`
- 19 test files / 92 tests / 98.58% statement coverage
- Node, Chromium, Firefox, WebKit, and Bun packed-consumer checks

## Complexity

Small request-boundary refactor using the existing Effect schema and typed validation-error pattern.

Part of #108.