### PR TITLE
fix(download-links): validate requests before transport

### DIFF
--- a/src/domains/download-links.ts
+++ b/src/domains/download-links.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from "effect";
 import { toCursorSelectionForm } from "../core/forms.js";
 import {
   definePutioOperationErrorSpec,
+  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
@@ -12,11 +13,16 @@ import {
   type PutioSdkContext,
 } from "../core/http.js";
 export const DownloadLinksStatusSchema = Schema.Literals(["NEW", "PROCESSING", "DONE", "ERROR"]);
+const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
 export const DownloadLinksCreateInputSchema = Schema.Struct({
-  cursor: Schema.optional(Schema.String),
-  excludeIds: Schema.optional(Schema.Array(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)))),
-  ids: Schema.optional(Schema.Array(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)))),
-});
+  cursor: Schema.optional(Schema.String.check(Schema.isMinLength(1))),
+  excludeIds: Schema.optional(Schema.Array(PositiveIdSchema)),
+  ids: Schema.optional(Schema.Array(PositiveIdSchema).check(Schema.isMinLength(1))),
+}).check(
+  Schema.makeFilter((input) => input.cursor !== undefined || input.ids !== undefined, {
+    expected: "a non-empty cursor or file ID selection",
+  }),
+);
 export const DownloadLinksPayloadSchema = Schema.Struct({
   download_links: Schema.Array(Schema.String),
   media_links: Schema.Array(Schema.String),
@@ -85,18 +91,31 @@ export const createDownloadLinks = (
   CreateDownloadLinksError,
   PutioSdkContext
 > =>
-  requestJson(DownloadLinksCreateEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: toCursorSelectionForm(input),
-    },
-    method: "POST",
-    path: "/v2/download_links/create",
-  }).pipe(selectJsonFields("id"), withOperationErrors(CreateDownloadLinksErrorSpec));
+  Schema.decodeUnknownEffect(DownloadLinksCreateInputSchema)(input).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(DownloadLinksCreateEnvelopeSchema, {
+        body: {
+          type: "form",
+          value: toCursorSelectionForm(decodedInput),
+        },
+        method: "POST",
+        path: "/v2/download_links/create",
+      }),
+    ),
+    selectJsonFields("id"),
+    withOperationErrors(CreateDownloadLinksErrorSpec),
+  );
 export const getDownloadLinks = (
   id: number,
 ): Effect.Effect<DownloadLinksInfo, GetDownloadLinksError, PutioSdkContext> =>
-  requestJson(DownloadLinksInfoSchema, {
-    method: "GET",
-    path: `/v2/download_links/${encodePathSegment(id)}`,
-  }).pipe(withOperationErrors(GetDownloadLinksErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(DownloadLinksInfoSchema, {
+        method: "GET",
+        path: `/v2/download_links/${encodePathSegment(decodedId)}`,
+      }),
+    ),
+    withOperationErrors(GetDownloadLinksErrorSpec),
+  );

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -484,28 +484,6 @@ describe("supporting domain boundaries", () => {
 
     expect(
       await runSdkEffect(
-        // @ts-expect-error This covers untyped JavaScript callers.
-        downloadLinks.getDownloadLinks("abc/def"),
-        (request) => {
-          expect(request.url).toBe("https://api.put.io/v2/download_links/abc%2Fdef");
-          return jsonResponse({
-            links: {
-              download_links: ["https://download.put.io/1"],
-              media_links: [],
-              mp4_links: [],
-            },
-            links_status: "DONE",
-            status: "OK",
-          });
-        },
-        { accessToken: "token-123" },
-      ),
-    ).toMatchObject({
-      links_status: "DONE",
-    });
-
-    expect(
-      await runSdkEffect(
         downloadLinks.getDownloadLinks(17),
         () =>
           jsonResponse({
@@ -574,6 +552,32 @@ describe("supporting domain boundaries", () => {
         ),
       ),
     ).toEqual([1, 2, 3]);
+  });
+
+  it("rejects invalid download-link inputs before transport", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+    const failures = await Promise.all([
+      runSdkExit(downloadLinks.createDownloadLinks(), handler),
+      runSdkExit(downloadLinks.createDownloadLinks({ cursor: "" }), handler),
+      runSdkExit(downloadLinks.createDownloadLinks({ ids: [] }), handler),
+      runSdkExit(downloadLinks.createDownloadLinks({ ids: [0] }), handler),
+      runSdkExit(downloadLinks.createDownloadLinks({ cursor: "cursor", excludeIds: [0] }), handler),
+      runSdkExit(
+        // @ts-expect-error JavaScript callers can provide non-numeric task IDs.
+        downloadLinks.getDownloadLinks("abc/def"),
+        handler,
+      ),
+      runSdkExit(downloadLinks.getDownloadLinks(0), handler),
+    ]);
+
+    expect(
+      failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
+    expect(requestCount).toBe(0);
   });
 
   it("covers family, friend invite, and friends endpoints", async () => {

--- a/test/live/domains/download-links.ts
+++ b/test/live/domains/download-links.ts
@@ -10,7 +10,7 @@ const { client } = await createClients({
 });
 
 const live = createLiveHarness("download-links live");
-const { assert, assertOperationError, finish, run, sleep } = live;
+const { assert, assertErrorTag, assertOperationError, finish, run, sleep } = live;
 
 void assertOperationError;
 void sleep;
@@ -232,14 +232,7 @@ await run("download links empty request fails before transport", async () => {
     await retryOnRateLimit(() => client.downloadLinks.create());
     throw new Error("expected empty create request to fail");
   } catch (error) {
-    assert(
-      typeof error === "object" &&
-        error !== null &&
-        "_tag" in error &&
-        error._tag === "PutioValidationError",
-      "expected empty selection to produce PutioValidationError",
-    );
-    return { tag: error._tag };
+    return assertErrorTag(error, { tag: "PutioValidationError" });
   }
 });
 

--- a/test/live/domains/download-links.ts
+++ b/test/live/domains/download-links.ts
@@ -227,17 +227,19 @@ await run("download links create supports cursor and exclude ids", async () => {
   }
 });
 
-await run("download links empty request yields typed bad request", async () => {
+await run("download links empty request fails before transport", async () => {
   try {
     await retryOnRateLimit(() => client.downloadLinks.create());
     throw new Error("expected empty create request to fail");
   } catch (error) {
-    return assertOperationError(error, {
-      domain: "downloadLinks",
-      errorType: "BadRequest",
-      operation: "create",
-      statusCode: 400,
-    });
+    assert(
+      typeof error === "object" &&
+        error !== null &&
+        "_tag" in error &&
+        error._tag === "PutioValidationError",
+      "expected empty selection to produce PutioValidationError",
+    );
+    return { tag: error._tag };
   }
 });
 


### PR DESCRIPTION
## Summary

Makes download-link selection and task-ID schemas enforceable outbound boundaries while preserving the existing public call signature.

## Changed

- Decodes create selections before form serialization.
- Requires a non-empty cursor or non-empty positive file-ID list.
- Rejects empty cursors, empty ID lists, non-positive selected/excluded IDs, non-numeric task IDs, and non-positive task IDs before transport.
- Decodes task IDs before path construction.
- Updates the live probe to expect local validation for an empty selection instead of deliberately issuing an API request that returns 400.

## Review aids

| SDK operation | Boundary proof |
| --- | --- |
| `downloadLinks.create` | Decode cursor/ID selection before CSV form serialization |
| `downloadLinks.get` | Decode a positive task ID before path construction |

Seven deterministic invalid inputs all produce `PutioValidationError` and the mock transport observes zero requests. The existing valid cursor-plus-ID request remains covered and keeps its wire format.

## Risks

- An empty create call now fails locally as `PutioValidationError` instead of reaching the API and mapping its 400 response.
- The Promise method remains optional at the TypeScript call site, avoiding a source-breaking signature change; runtime schema validation owns the invalid empty case.
- Supplying both a cursor and IDs remains accepted for compatibility, matching the existing serialized request behavior.

## Verification

- `pnpm exec vp run verify`
- `pnpm exec vp run lint:package`
- `pnpm exec vp run test:compat`
- 19 test files / 93 tests / 98.59% statement coverage
- Node, Chromium, Firefox, WebKit, and Bun packed-consumer checks

## Complexity

Small request-boundary change using the existing cursor-selection form and typed validation-error patterns.

Part of #108.