### PR TITLE
fix(rss): validate requests before transport

### DIFF
--- a/src/domains/ops.spec.ts
+++ b/src/domains/ops.spec.ts
@@ -194,6 +194,50 @@ describe("operational domain boundaries", () => {
     });
   });
 
+  it("rejects invalid rss inputs before transport", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+    const validParams = {
+      rss_source_url: "https://example.com/feed.xml",
+      title: "SDK Feed",
+    };
+    const failures = await Promise.all([
+      runSdkExit(rss.getRssFeed(0), handler),
+      // @ts-expect-error JavaScript callers can provide null instead of feed parameters.
+      runSdkExit(rss.createRssFeed(null), handler),
+      runSdkExit(rss.createRssFeed({ ...validParams, rss_source_url: "" }), handler),
+      runSdkExit(rss.createRssFeed({ ...validParams, title: "" }), handler),
+      runSdkExit(rss.createRssFeed({ ...validParams, parent_dir_id: -1 }), handler),
+      runSdkExit(
+        rss.createRssFeed({
+          ...validParams,
+          // @ts-expect-error JavaScript callers can provide non-boolean flags.
+          delete_old_files: "yes",
+        }),
+        handler,
+      ),
+      runSdkExit(rss.updateRssFeed(0, validParams), handler),
+      // @ts-expect-error JavaScript callers can provide null instead of feed parameters.
+      runSdkExit(rss.updateRssFeed(1, null), handler),
+      runSdkExit(rss.pauseRssFeed(0), handler),
+      runSdkExit(rss.resumeRssFeed(0), handler),
+      runSdkExit(rss.deleteRssFeed(0), handler),
+      runSdkExit(rss.listRssFeedItems(0), handler),
+      runSdkExit(rss.clearRssFeedLogs(0), handler),
+      runSdkExit(rss.retryRssFeedItem(0, 1), handler),
+      runSdkExit(rss.retryRssFeedItem(1, 0), handler),
+      runSdkExit(rss.retryAllRssFeedItems(0), handler),
+    ]);
+
+    expect(
+      failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
+    expect(requestCount).toBe(0);
+  });
+
   it("covers oauth endpoints and URL helpers", async () => {
     expect(
       oauth.buildOAuthAuthorizeUrl({

--- a/src/domains/rss.ts
+++ b/src/domains/rss.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect";
 import {
   definePutioOperationErrorSpec,
+  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
@@ -12,6 +13,8 @@ import {
   selectJsonFields,
   type PutioSdkContext,
 } from "../core/http.js";
+const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
+const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));
 export const RssFeedSchema = Schema.Struct({
   created_at: Schema.String,
   delete_old_files: Schema.Boolean,
@@ -38,9 +41,17 @@ export const RssFeedParamsSchema = Schema.Struct({
   parent_dir_id: Schema.optional(
     Schema.Union([Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)), Schema.Literal("newf")]),
   ),
-  rss_source_url: Schema.String,
-  title: Schema.String,
+  rss_source_url: NonEmptyStringSchema,
+  title: NonEmptyStringSchema,
   unwanted_keywords: Schema.optional(Schema.String),
+});
+const RssFeedUpdateInputSchema = Schema.Struct({
+  id: PositiveIdSchema,
+  params: RssFeedParamsSchema,
+});
+const RssFeedItemRetryInputSchema = Schema.Struct({
+  feedId: PositiveIdSchema,
+  itemId: PositiveIdSchema,
 });
 const RssFeedItemBaseSchema = Schema.Struct({
   detected_date: Schema.String,
@@ -231,21 +242,35 @@ export const listRssFeeds = (): Effect.Effect<
     path: "/v2/rss/list",
   }).pipe(selectJsonField("feeds"), withOperationErrors(ListRssFeedsErrorSpec));
 export const getRssFeed = (id: number): Effect.Effect<RssFeed, GetRssFeedError, PutioSdkContext> =>
-  requestJson(RssFeedEnvelopeSchema, {
-    method: "GET",
-    path: `/v2/rss/${encodePathSegment(id)}`,
-  }).pipe(selectJsonField("feed"), withOperationErrors(GetRssFeedErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(RssFeedEnvelopeSchema, {
+        method: "GET",
+        path: `/v2/rss/${encodePathSegment(decodedId)}`,
+      }),
+    ),
+    selectJsonField("feed"),
+    withOperationErrors(GetRssFeedErrorSpec),
+  );
 export const createRssFeed = (
   params: RssFeedParams,
 ): Effect.Effect<RssFeed, CreateRssFeedError, PutioSdkContext> =>
-  requestJson(RssFeedEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: toCreateBody(params),
-    },
-    method: "POST",
-    path: "/v2/rss/create",
-  }).pipe(selectJsonField("feed"), withOperationErrors(CreateRssFeedErrorSpec));
+  Schema.decodeUnknownEffect(RssFeedParamsSchema)(params).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedParams) =>
+      requestJson(RssFeedEnvelopeSchema, {
+        body: {
+          type: "form",
+          value: toCreateBody(decodedParams),
+        },
+        method: "POST",
+        path: "/v2/rss/create",
+      }),
+    ),
+    selectJsonField("feed"),
+    withOperationErrors(CreateRssFeedErrorSpec),
+  );
 export const updateRssFeed = (
   id: number,
   params: RssFeedParams,
@@ -254,21 +279,33 @@ export const updateRssFeed = (
   UpdateRssFeedError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: toUpdateBody(params),
-    },
-    method: "POST",
-    path: `/v2/rss/${encodePathSegment(id)}`,
-  }).pipe(withOperationErrors(UpdateRssFeedErrorSpec));
+  Schema.decodeUnknownEffect(RssFeedUpdateInputSchema)({ id, params }).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "form",
+          value: toUpdateBody(decodedInput.params),
+        },
+        method: "POST",
+        path: `/v2/rss/${encodePathSegment(decodedInput.id)}`,
+      }),
+    ),
+    withOperationErrors(UpdateRssFeedErrorSpec),
+  );
 export const pauseRssFeed = (
   id: number,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PauseRssFeedError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/rss/${encodePathSegment(id)}/pause`,
-  }).pipe(withOperationErrors(PauseRssFeedErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/rss/${encodePathSegment(decodedId)}/pause`,
+      }),
+    ),
+    withOperationErrors(PauseRssFeedErrorSpec),
+  );
 export const resumeRssFeed = (
   id: number,
 ): Effect.Effect<
@@ -276,10 +313,16 @@ export const resumeRssFeed = (
   ResumeRssFeedError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/rss/${encodePathSegment(id)}/resume`,
-  }).pipe(withOperationErrors(ResumeRssFeedErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/rss/${encodePathSegment(decodedId)}/resume`,
+      }),
+    ),
+    withOperationErrors(ResumeRssFeedErrorSpec),
+  );
 export const deleteRssFeed = (
   id: number,
 ): Effect.Effect<
@@ -287,10 +330,16 @@ export const deleteRssFeed = (
   DeleteRssFeedError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/rss/${encodePathSegment(id)}/delete`,
-  }).pipe(withOperationErrors(DeleteRssFeedErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/rss/${encodePathSegment(decodedId)}/delete`,
+      }),
+    ),
+    withOperationErrors(DeleteRssFeedErrorSpec),
+  );
 export const listRssFeedItems = (
   id: number,
 ): Effect.Effect<
@@ -301,10 +350,17 @@ export const listRssFeedItems = (
   ListRssFeedItemsError,
   PutioSdkContext
 > =>
-  requestJson(RssFeedItemsEnvelopeSchema, {
-    method: "GET",
-    path: `/v2/rss/${encodePathSegment(id)}/items`,
-  }).pipe(selectJsonFields("feed", "items"), withOperationErrors(ListRssFeedItemsErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(RssFeedItemsEnvelopeSchema, {
+        method: "GET",
+        path: `/v2/rss/${encodePathSegment(decodedId)}/items`,
+      }),
+    ),
+    selectJsonFields("feed", "items"),
+    withOperationErrors(ListRssFeedItemsErrorSpec),
+  );
 export const clearRssFeedLogs = (
   id: number,
 ): Effect.Effect<
@@ -312,10 +368,16 @@ export const clearRssFeedLogs = (
   ClearRssFeedLogsError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/rss/${encodePathSegment(id)}/clear-log`,
-  }).pipe(withOperationErrors(ClearRssFeedLogsErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/rss/${encodePathSegment(decodedId)}/clear-log`,
+      }),
+    ),
+    withOperationErrors(ClearRssFeedLogsErrorSpec),
+  );
 export const retryRssFeedItem = (
   feedId: number,
   itemId: number,
@@ -324,10 +386,16 @@ export const retryRssFeedItem = (
   RetryRssFeedItemError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/rss/${encodePathSegment(feedId)}/items/${encodePathSegment(itemId)}/retry`,
-  }).pipe(withOperationErrors(RetryRssFeedItemErrorSpec));
+  Schema.decodeUnknownEffect(RssFeedItemRetryInputSchema)({ feedId, itemId }).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/rss/${encodePathSegment(decodedInput.feedId)}/items/${encodePathSegment(decodedInput.itemId)}/retry`,
+      }),
+    ),
+    withOperationErrors(RetryRssFeedItemErrorSpec),
+  );
 export const retryAllRssFeedItems = (
   feedId: number,
 ): Effect.Effect<
@@ -335,7 +403,13 @@ export const retryAllRssFeedItems = (
   RetryAllRssFeedItemsError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/rss/${encodePathSegment(feedId)}/retry-all`,
-  }).pipe(withOperationErrors(RetryAllRssFeedItemsErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(feedId).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedFeedId) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/rss/${encodePathSegment(decodedFeedId)}/retry-all`,
+      }),
+    ),
+    withOperationErrors(RetryAllRssFeedItemsErrorSpec),
+  );


### PR DESCRIPTION
## Summary

Validate RSS request parameters and resource IDs through Effect schemas before building form bodies or URL paths.

## Changed

- Decode feed create/update parameters before form serialization.
- Validate positive feed/item IDs before every path-based RSS operation.
- Require non-empty source URLs and titles while preserving the existing backend-facing form transformations.
- Cover 16 malformed runtime inputs with typed `PutioValidationError` failures and zero requests.

## Review aids

```mermaid
flowchart LR
  A["runtime RSS input"] --> B["Effect Schema decode"]
  B -->|valid| C["existing form or path serializer"]
  C --> D["RSS API request"]
  B -->|invalid| E["PutioValidationError"]
  E --> F["zero transport calls"]
```

The existing `covers rss endpoints` test is the positive reference for create/update form fields and all successful path operations.

## Risks

- Zero feed/item IDs, empty source URLs or titles, negative parent IDs, and wrong flag types now fail locally instead of reaching the backend.
- No public method signatures or successful response contracts change.

## Verification

- `pnpm exec vp run verify` — 19 files, 95 tests, 98.61% statements
- `pnpm exec vp run lint:package`
- `pnpm exec vp run test:compat` — Node, Chromium, Firefox, WebKit, Bun

## Complexity

Low. This wraps existing request construction with schema decoding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate RSS inputs before transport to prevent invalid requests and surface clear errors. Invalid parameters now fail fast with `PutioValidationError` without making any network calls.

- **Bug Fixes**
  - Added schema checks for positive feed/item IDs and non-empty `rss_source_url` and `title`, mapping decode errors to `PutioValidationError`.
  - Applied validation across all RSS endpoints (including item retries) and added tests verifying early rejection and zero request count.

<sup>Written for commit e13a420325cf2494a82f27d035f6e415a25025aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

