### PR TITLE
fix(events): validate requests before transport

### DIFF
--- a/src/domains/events.ts
+++ b/src/domains/events.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect";
 import {
   definePutioOperationErrorSpec,
+  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
@@ -11,6 +12,7 @@ import {
   requestJson,
   type PutioSdkContext,
 } from "../core/http.js";
+const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
 const HistoryEventBaseSchema = Schema.Struct({
   created_at: Schema.String,
   id: Schema.Int,
@@ -207,18 +209,30 @@ export type GetEventTorrentError = PutioOperationFailure<typeof GetEventTorrentE
 export const listEvents = (
   query: EventsListQuery = {},
 ): Effect.Effect<EventsListResponse, ListEventsError, PutioSdkContext> =>
-  requestJson(EventsListEnvelopeSchema, {
-    method: "GET",
-    path: "/v2/events/list",
-    query,
-  }).pipe(withOperationErrors(ListEventsErrorSpec));
+  Schema.decodeUnknownEffect(EventsListQuerySchema)(query).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedQuery) =>
+      requestJson(EventsListEnvelopeSchema, {
+        method: "GET",
+        path: "/v2/events/list",
+        query: decodedQuery,
+      }),
+    ),
+    withOperationErrors(ListEventsErrorSpec),
+  );
 export const deleteEvent = (
   id: number,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, DeleteEventError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/events/delete/${encodePathSegment(id)}`,
-  }).pipe(withOperationErrors(DeleteEventErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/events/delete/${encodePathSegment(decodedId)}`,
+      }),
+    ),
+    withOperationErrors(DeleteEventErrorSpec),
+  );
 export const clearEvents = (): Effect.Effect<
   Schema.Schema.Type<typeof OkResponseSchema>,
   ClearEventsError,
@@ -231,7 +245,13 @@ export const clearEvents = (): Effect.Effect<
 export const getEventTorrent = (
   id: number,
 ): Effect.Effect<Uint8Array, GetEventTorrentError, PutioSdkContext> =>
-  requestArrayBuffer({
-    method: "GET",
-    path: `/v2/events/${encodePathSegment(id)}/torrent`,
-  }).pipe(withOperationErrors(GetEventTorrentErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestArrayBuffer({
+        method: "GET",
+        path: `/v2/events/${encodePathSegment(decodedId)}/torrent`,
+      }),
+    ),
+    withOperationErrors(GetEventTorrentErrorSpec),
+  );

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -554,6 +554,27 @@ describe("supporting domain boundaries", () => {
     ).toEqual([1, 2, 3]);
   });
 
+  it("rejects invalid event inputs before transport", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+    const failures = await Promise.all([
+      // @ts-expect-error JavaScript callers can provide null instead of a query object.
+      runSdkExit(events.listEvents(null), handler),
+      runSdkExit(events.listEvents({ before: 0 }), handler),
+      runSdkExit(events.listEvents({ per_page: 0 }), handler),
+      runSdkExit(events.deleteEvent(0), handler),
+      runSdkExit(events.getEventTorrent(0), handler),
+    ]);
+
+    expect(
+      failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
+    expect(requestCount).toBe(0);
+  });
+
   it("rejects invalid download-link inputs before transport", async () => {
     let requestCount = 0;
     const handler = () => {


### PR DESCRIPTION
## Summary

Validate event list queries and event IDs through Effect schemas before query or path serialization.

## Changed

- Decode `events.list` pagination inputs before building the query string.
- Validate positive event IDs before delete and torrent paths are constructed.
- Cover null queries, zero pagination values, and zero IDs with typed `PutioValidationError` failures and zero requests.

## Review aids

```mermaid
flowchart LR
  A["runtime event input"] --> B["Effect Schema decode"]
  B -->|valid| C["query or path serialization"]
  C --> D["events API request"]
  B -->|invalid| E["PutioValidationError with zero transport"]
```

The existing event endpoint test remains the positive reference for pagination, deletion, clearing, and binary torrent responses.

## Risks

- Zero event IDs and non-positive pagination values now fail locally.
- No public method signatures or successful response contracts change.

## Verification

- `pnpm exec vp run verify` — 19 files, 96 tests, 98.61% statements
- `pnpm exec vp run lint:package`
- `pnpm exec vp run test:compat` — Node, Chromium, Firefox, WebKit, Bun

## Complexity

Low. This adds schema decoding around three existing request builders.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate events API inputs before sending network requests. Invalid params now fail fast with `PutioValidationError` and no HTTP calls.

- **Bug Fixes**
  - `events.listEvents`: decode and validate queries (including `null` and non-positive pagination) with `EventsListQuerySchema` before request.
  - `events.deleteEvent` and `events.getEventTorrent`: require positive `id`; validate before path encoding.
  - Map decode failures to `PutioValidationError`; tests confirm short-circuiting (zero requests).

<sup>Written for commit 8ff0555ae6eef7da57342622d12c1e6531104e9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

