### PR TITLE
fix(files): validate trash and zip requests

### DIFF
--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -170,6 +170,16 @@ const decodeSuccessJson = <S extends Schema.Top>(schema: S, response: PutioHttpR
     Effect.mapError(mapDecodeErrorToValidationError),
   );
 
+export const decodeAndRun = <S extends Schema.Top, A, E, R>(
+  schema: S,
+  input: unknown,
+  run: (decoded: S["Type"]) => Effect.Effect<A, E, R>,
+) =>
+  Schema.decodeUnknownEffect(schema)(input).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap(run),
+  );
+
 const decodeFailure = (response: PutioHttpResponse, headers: Headers) =>
   response.json.pipe(
     Effect.flatMap((json) => parseErrorBody(response.status, json)),

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -170,16 +170,6 @@ const decodeSuccessJson = <S extends Schema.Top>(schema: S, response: PutioHttpR
     Effect.mapError(mapDecodeErrorToValidationError),
   );
 
-export const decodeAndRun = <S extends Schema.Top, A, E, R>(
-  schema: S,
-  input: unknown,
-  run: (decoded: S["Type"]) => Effect.Effect<A, E, R>,
-) =>
-  Schema.decodeUnknownEffect(schema)(input).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap(run),
-  );
-
 const decodeFailure = (response: PutioHttpResponse, headers: Headers) =>
   response.json.pipe(
     Effect.flatMap((json) => parseErrorBody(response.status, json)),

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -1,0 +1,4 @@
+import { Schema } from "effect";
+
+export const PositiveIntegerSchema = Schema.Int.check(Schema.isGreaterThan(0));
+export const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -1,7 +1,19 @@
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
+
+import { mapDecodeErrorToValidationError } from "./errors.js";
 
 export const PositiveIntegerSchema = Schema.Int.check(Schema.isGreaterThan(0));
 export const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));
+
+export const decodeAndRun = <S extends Schema.Top, A, E, R>(
+  schema: S,
+  input: unknown,
+  run: (decoded: S["Type"]) => Effect.Effect<A, E, R>,
+) =>
+  Schema.decodeUnknownEffect(schema)(input).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap(run),
+  );
 
 export const makeCursorSelectionSchema = <
   const TIdsField extends string,

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -2,3 +2,20 @@ import { Schema } from "effect";
 
 export const PositiveIntegerSchema = Schema.Int.check(Schema.isGreaterThan(0));
 export const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));
+
+export const makeCursorSelectionSchema = <
+  const TIdsField extends string,
+  const TExcludeIdsField extends string,
+>(
+  idsField: TIdsField,
+  excludeIdsField: TExcludeIdsField,
+) =>
+  Schema.Struct({
+    cursor: Schema.optional(NonEmptyStringSchema),
+    [excludeIdsField]: Schema.optional(Schema.Array(PositiveIntegerSchema)),
+    [idsField]: Schema.optional(Schema.Array(PositiveIntegerSchema).check(Schema.isMinLength(1))),
+  }).check(
+    Schema.makeFilter((input) => input.cursor !== undefined || input[idsField] !== undefined, {
+      expected: "a non-empty cursor or file ID selection",
+    }),
+  );

--- a/src/domains/download-links.ts
+++ b/src/domains/download-links.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema } from "effect";
 import { toCursorSelectionForm } from "../core/forms.js";
-import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
+import { PositiveIntegerSchema, makeCursorSelectionSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   mapDecodeErrorToValidationError,
@@ -14,15 +14,7 @@ import {
   type PutioSdkContext,
 } from "../core/http.js";
 export const DownloadLinksStatusSchema = Schema.Literals(["NEW", "PROCESSING", "DONE", "ERROR"]);
-export const DownloadLinksCreateInputSchema = Schema.Struct({
-  cursor: Schema.optional(NonEmptyStringSchema),
-  excludeIds: Schema.optional(Schema.Array(PositiveIntegerSchema)),
-  ids: Schema.optional(Schema.Array(PositiveIntegerSchema).check(Schema.isMinLength(1))),
-}).check(
-  Schema.makeFilter((input) => input.cursor !== undefined || input.ids !== undefined, {
-    expected: "a non-empty cursor or file ID selection",
-  }),
-);
+export const DownloadLinksCreateInputSchema = makeCursorSelectionSchema("ids", "excludeIds");
 export const DownloadLinksPayloadSchema = Schema.Struct({
   download_links: Schema.Array(Schema.String),
   media_links: Schema.Array(Schema.String),

--- a/src/domains/download-links.ts
+++ b/src/domains/download-links.ts
@@ -1,5 +1,6 @@
 import { Effect, Schema } from "effect";
 import { toCursorSelectionForm } from "../core/forms.js";
+import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   mapDecodeErrorToValidationError,
@@ -13,11 +14,10 @@ import {
   type PutioSdkContext,
 } from "../core/http.js";
 export const DownloadLinksStatusSchema = Schema.Literals(["NEW", "PROCESSING", "DONE", "ERROR"]);
-const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
 export const DownloadLinksCreateInputSchema = Schema.Struct({
-  cursor: Schema.optional(Schema.String.check(Schema.isMinLength(1))),
-  excludeIds: Schema.optional(Schema.Array(PositiveIdSchema)),
-  ids: Schema.optional(Schema.Array(PositiveIdSchema).check(Schema.isMinLength(1))),
+  cursor: Schema.optional(NonEmptyStringSchema),
+  excludeIds: Schema.optional(Schema.Array(PositiveIntegerSchema)),
+  ids: Schema.optional(Schema.Array(PositiveIntegerSchema).check(Schema.isMinLength(1))),
 }).check(
   Schema.makeFilter((input) => input.cursor !== undefined || input.ids !== undefined, {
     expected: "a non-empty cursor or file ID selection",
@@ -109,7 +109,7 @@ export const createDownloadLinks = (
 export const getDownloadLinks = (
   id: number,
 ): Effect.Effect<DownloadLinksInfo, GetDownloadLinksError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(DownloadLinksInfoSchema, {

--- a/src/domains/events.ts
+++ b/src/domains/events.ts
@@ -1,4 +1,5 @@
 import { Effect, Schema } from "effect";
+import { PositiveIntegerSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   mapDecodeErrorToValidationError,
@@ -12,7 +13,6 @@ import {
   requestJson,
   type PutioSdkContext,
 } from "../core/http.js";
-const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
 const HistoryEventBaseSchema = Schema.Struct({
   created_at: Schema.String,
   id: Schema.Int,
@@ -223,7 +223,7 @@ export const listEvents = (
 export const deleteEvent = (
   id: number,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, DeleteEventError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(OkResponseSchema, {
@@ -245,7 +245,7 @@ export const clearEvents = (): Effect.Effect<
 export const getEventTorrent = (
   id: number,
 ): Effect.Effect<Uint8Array, GetEventTorrentError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestArrayBuffer({

--- a/src/domains/ops.spec.ts
+++ b/src/domains/ops.spec.ts
@@ -1226,7 +1226,17 @@ describe("operational domain boundaries", () => {
       runSdkExit(trash.restoreTrash({}), handler),
       runSdkExit(trash.restoreTrash({ cursor: "", useCursor: true }), handler),
       runSdkExit(trash.restoreTrash({ file_ids: [] }), handler),
+      runSdkExit(
+        // @ts-expect-error Cursor mode cannot also carry explicit file IDs.
+        trash.restoreTrash({ cursor: "cursor", file_ids: [1], useCursor: true }),
+        handler,
+      ),
       runSdkExit(trash.deleteTrash({ file_ids: [0] }), handler),
+      runSdkExit(
+        // @ts-expect-error File-ID mode cannot also carry a cursor.
+        trash.deleteTrash({ cursor: "cursor", file_ids: [1], useCursor: false }),
+        handler,
+      ),
       // @ts-expect-error Cursor selection must opt into cursor serialization.
       runSdkExit(trash.deleteTrash({ cursor: "cursor" }), handler),
       // @ts-expect-error JavaScript callers can provide null instead of a request object.

--- a/src/domains/ops.spec.ts
+++ b/src/domains/ops.spec.ts
@@ -1096,10 +1096,6 @@ describe("operational domain boundaries", () => {
       accessToken: "token-123",
     });
 
-    expect(() => trash.restoreTrash({} as never)).toThrow(
-      "trash bulk file_ids are required when useCursor is not set",
-    );
-
     expect(
       await runSdkEffect(
         zips.listZips(),
@@ -1204,6 +1200,45 @@ describe("operational domain boundaries", () => {
         handler,
         { accessToken: "token-123" },
       ),
+    ]);
+
+    expect(
+      failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
+    expect(requestCount).toBe(0);
+  });
+
+  it("rejects invalid trash and zip inputs before transport", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+    const failures = await Promise.all([
+      // @ts-expect-error JavaScript callers can provide null instead of a query object.
+      runSdkExit(trash.listTrash(null), handler),
+      runSdkExit(trash.listTrash({ per_page: 0 }), handler),
+      runSdkExit(trash.continueTrash(""), handler),
+      runSdkExit(trash.continueTrash("cursor", { per_page: 0 }), handler),
+      // @ts-expect-error JavaScript callers can provide null instead of a query object.
+      runSdkExit(trash.continueTrash("cursor", null), handler),
+      // @ts-expect-error JavaScript callers can omit both bulk selectors.
+      runSdkExit(trash.restoreTrash({}), handler),
+      runSdkExit(trash.restoreTrash({ cursor: "", useCursor: true }), handler),
+      runSdkExit(trash.restoreTrash({ file_ids: [] }), handler),
+      runSdkExit(trash.deleteTrash({ file_ids: [0] }), handler),
+      // @ts-expect-error Cursor selection must opt into cursor serialization.
+      runSdkExit(trash.deleteTrash({ cursor: "cursor" }), handler),
+      // @ts-expect-error JavaScript callers can provide null instead of a request object.
+      runSdkExit(zips.createZip(null), handler),
+      // @ts-expect-error JavaScript callers can omit both zip selectors.
+      runSdkExit(zips.createZip({}), handler),
+      runSdkExit(zips.createZip({ cursor: "" }), handler),
+      runSdkExit(zips.createZip({ file_ids: [] }), handler),
+      runSdkExit(zips.createZip({ file_ids: [0] }), handler),
+      runSdkExit(zips.createZip({ cursor: "cursor", exclude_ids: [0] }), handler),
+      runSdkExit(zips.getZip(0), handler),
+      runSdkExit(zips.cancelZip(0), handler),
     ]);
 
     expect(

--- a/src/domains/rss.ts
+++ b/src/domains/rss.ts
@@ -1,4 +1,5 @@
 import { Effect, Schema } from "effect";
+import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   mapDecodeErrorToValidationError,
@@ -13,8 +14,6 @@ import {
   selectJsonFields,
   type PutioSdkContext,
 } from "../core/http.js";
-const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
-const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));
 export const RssFeedSchema = Schema.Struct({
   created_at: Schema.String,
   delete_old_files: Schema.Boolean,
@@ -46,12 +45,12 @@ export const RssFeedParamsSchema = Schema.Struct({
   unwanted_keywords: Schema.optional(Schema.String),
 });
 const RssFeedUpdateInputSchema = Schema.Struct({
-  id: PositiveIdSchema,
+  id: PositiveIntegerSchema,
   params: RssFeedParamsSchema,
 });
 const RssFeedItemRetryInputSchema = Schema.Struct({
-  feedId: PositiveIdSchema,
-  itemId: PositiveIdSchema,
+  feedId: PositiveIntegerSchema,
+  itemId: PositiveIntegerSchema,
 });
 const RssFeedItemBaseSchema = Schema.Struct({
   detected_date: Schema.String,
@@ -242,7 +241,7 @@ export const listRssFeeds = (): Effect.Effect<
     path: "/v2/rss/list",
   }).pipe(selectJsonField("feeds"), withOperationErrors(ListRssFeedsErrorSpec));
 export const getRssFeed = (id: number): Effect.Effect<RssFeed, GetRssFeedError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(RssFeedEnvelopeSchema, {
@@ -296,7 +295,7 @@ export const updateRssFeed = (
 export const pauseRssFeed = (
   id: number,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PauseRssFeedError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(OkResponseSchema, {
@@ -313,7 +312,7 @@ export const resumeRssFeed = (
   ResumeRssFeedError,
   PutioSdkContext
 > =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(OkResponseSchema, {
@@ -330,7 +329,7 @@ export const deleteRssFeed = (
   DeleteRssFeedError,
   PutioSdkContext
 > =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(OkResponseSchema, {
@@ -350,7 +349,7 @@ export const listRssFeedItems = (
   ListRssFeedItemsError,
   PutioSdkContext
 > =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(RssFeedItemsEnvelopeSchema, {
@@ -368,7 +367,7 @@ export const clearRssFeedLogs = (
   ClearRssFeedLogsError,
   PutioSdkContext
 > =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(OkResponseSchema, {
@@ -403,7 +402,7 @@ export const retryAllRssFeedItems = (
   RetryAllRssFeedItemsError,
   PutioSdkContext
 > =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(feedId).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(feedId).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedFeedId) =>
       requestJson(OkResponseSchema, {

--- a/src/domains/sharing.ts
+++ b/src/domains/sharing.ts
@@ -1,5 +1,6 @@
 import { Effect, Schema } from "effect";
 import { joinCsv, toCursorSelectionForm } from "../core/forms.js";
+import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   mapDecodeErrorToValidationError,
@@ -16,12 +17,10 @@ import {
   type PutioSdkContext,
 } from "../core/http.js";
 export const SharingCloneStatusSchema = Schema.Literals(["NEW", "PROCESSING", "DONE", "ERROR"]);
-const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
-const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));
 export const SharingCloneInputSchema = Schema.Struct({
   cursor: Schema.optional(NonEmptyStringSchema),
-  excludeIds: Schema.optional(Schema.Array(PositiveIdSchema)),
-  ids: Schema.optional(Schema.Array(PositiveIdSchema)),
+  excludeIds: Schema.optional(Schema.Array(PositiveIntegerSchema)),
+  ids: Schema.optional(Schema.Array(PositiveIntegerSchema)),
   parentId: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
 });
 const SharingCloneEnvelopeSchema = Schema.Struct({
@@ -49,8 +48,8 @@ export const SharedFileSchema = FileBroadSchema.pipe(
 );
 export const SharingShareInputSchema = Schema.Struct({
   cursor: Schema.optional(NonEmptyStringSchema),
-  excludeIds: Schema.optional(Schema.Array(PositiveIdSchema)),
-  ids: Schema.optional(Schema.Array(PositiveIdSchema)),
+  excludeIds: Schema.optional(Schema.Array(PositiveIntegerSchema)),
+  ids: Schema.optional(Schema.Array(PositiveIntegerSchema)),
   target: Schema.Union([
     Schema.Struct({
       type: Schema.Literal("everyone"),
@@ -82,8 +81,10 @@ export const SharedFileSharedWithSchema = Schema.Union([
   }),
 ]);
 export const SharingUnshareInputSchema = Schema.Struct({
-  fileId: PositiveIdSchema,
-  shares: Schema.optional(Schema.Array(Schema.Union([PositiveIdSchema, NonEmptyStringSchema]))),
+  fileId: PositiveIntegerSchema,
+  shares: Schema.optional(
+    Schema.Array(Schema.Union([PositiveIntegerSchema, NonEmptyStringSchema])),
+  ),
 });
 export const PublicShareSchema = Schema.Struct({
   created_at: Schema.String,
@@ -325,7 +326,7 @@ export const cloneSharedFiles = (
 export const getSharingCloneInfo = (
   id: number,
 ): Effect.Effect<SharingCloneInfo, GetSharingCloneInfoError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(SharingCloneInfoSchema, {
@@ -367,7 +368,7 @@ export const listSharedFiles = (): Effect.Effect<
 export const getSharedWith = (
   fileId: number,
 ): Effect.Effect<SharedFileSharedWith, GetSharedWithError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(fileId).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(fileId).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedFileId) =>
       requestJson(SharedFileSharedWithSchema, {
@@ -399,7 +400,7 @@ export const unshareFile = (
 export const createPublicShare = (
   fileId: number,
 ): Effect.Effect<PublicShare, CreatePublicShareError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(fileId).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(fileId).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedFileId) =>
       requestJson(PublicShareEnvelopeSchema, {
@@ -426,7 +427,7 @@ export const deletePublicShare = (
   DeletePublicShareError,
   PutioSdkContext
 > =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(OkResponseSchema, {
@@ -491,7 +492,7 @@ export const continuePublicShareFiles = (
 export const getPublicShareFileUrl = (
   fileId: number,
 ): Effect.Effect<string, GetPublicShareFileUrlError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(fileId).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(fileId).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedFileId) =>
       requestJson(PublicShareFileUrlEnvelopeSchema, {

--- a/src/domains/trash.ts
+++ b/src/domains/trash.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect";
 
 import { joinCsv } from "../core/forms.js";
+import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   mapDecodeErrorToValidationError,
@@ -44,10 +45,8 @@ const TrashContinueEnvelopeSchema = Schema.Struct({
 export type TrashFile = Schema.Schema.Type<typeof TrashFileSchema>;
 export type TrashListResponse = Schema.Schema.Type<typeof TrashListEnvelopeSchema>;
 export type TrashContinueResponse = Schema.Schema.Type<typeof TrashContinueEnvelopeSchema>;
-const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
-const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));
 const TrashListQuerySchema = Schema.Struct({
-  per_page: Schema.optional(PositiveIdSchema),
+  per_page: Schema.optional(PositiveIntegerSchema),
 });
 const TrashCursorBulkInputSchema = Schema.Struct({
   cursor: NonEmptyStringSchema,
@@ -56,7 +55,7 @@ const TrashCursorBulkInputSchema = Schema.Struct({
 });
 const TrashIdsBulkInputSchema = Schema.Struct({
   cursor: Schema.optional(Schema.Never),
-  file_ids: Schema.Array(PositiveIdSchema).check(Schema.isMinLength(1)),
+  file_ids: Schema.Array(PositiveIntegerSchema).check(Schema.isMinLength(1)),
   useCursor: Schema.optional(Schema.Literal(false)),
 });
 const TrashBulkInputSchema = Schema.Union([TrashCursorBulkInputSchema, TrashIdsBulkInputSchema]);

--- a/src/domains/trash.ts
+++ b/src/domains/trash.ts
@@ -51,11 +51,11 @@ const TrashListQuerySchema = Schema.Struct({
 });
 const TrashCursorBulkInputSchema = Schema.Struct({
   cursor: NonEmptyStringSchema,
-  file_ids: Schema.optional(Schema.Array(PositiveIdSchema)),
+  file_ids: Schema.optional(Schema.Never),
   useCursor: Schema.Literal(true),
 });
 const TrashIdsBulkInputSchema = Schema.Struct({
-  cursor: Schema.optional(NonEmptyStringSchema),
+  cursor: Schema.optional(Schema.Never),
   file_ids: Schema.Array(PositiveIdSchema).check(Schema.isMinLength(1)),
   useCursor: Schema.optional(Schema.Literal(false)),
 });

--- a/src/domains/trash.ts
+++ b/src/domains/trash.ts
@@ -3,6 +3,7 @@ import { Effect, Schema } from "effect";
 import { joinCsv } from "../core/forms.js";
 import {
   definePutioOperationErrorSpec,
+  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
@@ -43,22 +44,28 @@ const TrashContinueEnvelopeSchema = Schema.Struct({
 export type TrashFile = Schema.Schema.Type<typeof TrashFileSchema>;
 export type TrashListResponse = Schema.Schema.Type<typeof TrashListEnvelopeSchema>;
 export type TrashContinueResponse = Schema.Schema.Type<typeof TrashContinueEnvelopeSchema>;
-
-export type TrashListQuery = {
-  readonly per_page?: number;
-};
-
-export type TrashBulkInput =
-  | {
-      readonly cursor: string;
-      readonly file_ids?: ReadonlyArray<number>;
-      readonly useCursor?: true;
-    }
-  | {
-      readonly cursor?: string;
-      readonly file_ids: ReadonlyArray<number>;
-      readonly useCursor?: false;
-    };
+const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
+const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));
+const TrashListQuerySchema = Schema.Struct({
+  per_page: Schema.optional(PositiveIdSchema),
+});
+const TrashCursorBulkInputSchema = Schema.Struct({
+  cursor: NonEmptyStringSchema,
+  file_ids: Schema.optional(Schema.Array(PositiveIdSchema)),
+  useCursor: Schema.Literal(true),
+});
+const TrashIdsBulkInputSchema = Schema.Struct({
+  cursor: Schema.optional(NonEmptyStringSchema),
+  file_ids: Schema.Array(PositiveIdSchema).check(Schema.isMinLength(1)),
+  useCursor: Schema.optional(Schema.Literal(false)),
+});
+const TrashBulkInputSchema = Schema.Union([TrashCursorBulkInputSchema, TrashIdsBulkInputSchema]);
+const TrashContinueInputSchema = Schema.Struct({
+  cursor: NonEmptyStringSchema,
+  query: TrashListQuerySchema,
+});
+export type TrashListQuery = Schema.Schema.Type<typeof TrashListQuerySchema>;
+export type TrashBulkInput = Schema.Schema.Type<typeof TrashBulkInputSchema>;
 
 const RestrictedReadError = { errorType: "invalid_scope", statusCode: 401 as const };
 const RestrictedWriteError = { errorType: "invalid_scope", statusCode: 401 as const };
@@ -117,17 +124,12 @@ export type DeleteTrashError = PutioOperationFailure<typeof DeleteTrashErrorSpec
 export type EmptyTrashError = PutioOperationFailure<typeof EmptyTrashErrorSpec>;
 
 const toBulkTrashBody = (input: TrashBulkInput) => {
-  if (input.useCursor) {
+  if (input.useCursor === true) {
     return {
       cursor: input.cursor,
       file_ids: undefined,
     };
   }
-
-  if (!input.file_ids) {
-    throw new Error("trash bulk file_ids are required when useCursor is not set");
-  }
-
   return {
     cursor: undefined,
     file_ids: joinCsv(input.file_ids),
@@ -135,53 +137,79 @@ const toBulkTrashBody = (input: TrashBulkInput) => {
 };
 
 export const listTrash = (
-  query?: TrashListQuery,
+  query: TrashListQuery = {},
 ): Effect.Effect<TrashListResponse, ListTrashError, PutioSdkContext> =>
-  requestJson(TrashListEnvelopeSchema, {
-    method: "GET",
-    path: "/v2/trash/list",
-    query,
-  }).pipe(withOperationErrors(ListTrashErrorSpec));
+  Schema.decodeUnknownEffect(TrashListQuerySchema)(query).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedQuery) =>
+      requestJson(TrashListEnvelopeSchema, {
+        method: "GET",
+        path: "/v2/trash/list",
+        query: decodedQuery,
+      }),
+    ),
+    withOperationErrors(ListTrashErrorSpec),
+  );
 
 export const continueTrash = (
   cursor: string,
-  query?: TrashListQuery,
+  query: TrashListQuery = {},
 ): Effect.Effect<TrashContinueResponse, ContinueTrashError, PutioSdkContext> =>
-  requestJson(TrashContinueEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: {
-        cursor,
-      },
-    },
-    method: "POST",
-    path: "/v2/trash/list/continue",
-    query,
-  }).pipe(withOperationErrors(ContinueTrashErrorSpec));
+  Schema.decodeUnknownEffect(TrashContinueInputSchema)({ cursor, query }).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(TrashContinueEnvelopeSchema, {
+        body: {
+          type: "form",
+          value: {
+            cursor: decodedInput.cursor,
+          },
+        },
+        method: "POST",
+        path: "/v2/trash/list/continue",
+        query: decodedInput.query,
+      }),
+    ),
+    withOperationErrors(ContinueTrashErrorSpec),
+  );
 
 export const restoreTrash = (
   input: TrashBulkInput,
 ): Effect.Effect<void, RestoreTrashError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: toBulkTrashBody(input),
-    },
-    method: "POST",
-    path: "/v2/trash/restore",
-  }).pipe(Effect.asVoid, withOperationErrors(RestoreTrashErrorSpec));
+  Schema.decodeUnknownEffect(TrashBulkInputSchema)(input).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "form",
+          value: toBulkTrashBody(decodedInput),
+        },
+        method: "POST",
+        path: "/v2/trash/restore",
+      }),
+    ),
+    Effect.asVoid,
+    withOperationErrors(RestoreTrashErrorSpec),
+  );
 
 export const deleteTrash = (
   input: TrashBulkInput,
 ): Effect.Effect<void, DeleteTrashError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: toBulkTrashBody(input),
-    },
-    method: "POST",
-    path: "/v2/trash/delete",
-  }).pipe(Effect.asVoid, withOperationErrors(DeleteTrashErrorSpec));
+  Schema.decodeUnknownEffect(TrashBulkInputSchema)(input).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(OkResponseSchema, {
+        body: {
+          type: "form",
+          value: toBulkTrashBody(decodedInput),
+        },
+        method: "POST",
+        path: "/v2/trash/delete",
+      }),
+    ),
+    Effect.asVoid,
+    withOperationErrors(DeleteTrashErrorSpec),
+  );
 
 export const emptyTrash = (): Effect.Effect<void, EmptyTrashError, PutioSdkContext> =>
   requestJson(OkResponseSchema, {

--- a/src/domains/trash.ts
+++ b/src/domains/trash.ts
@@ -4,12 +4,11 @@ import { joinCsv } from "../core/forms.js";
 import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
-  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
 import { FileTypeSchema } from "./files.js";
-import { OkResponseSchema, requestJson, type PutioSdkContext } from "../core/http.js";
+import { OkResponseSchema, decodeAndRun, requestJson, type PutioSdkContext } from "../core/http.js";
 
 export const TrashFileSchema = Schema.Struct({
   content_type: Schema.NullOr(Schema.String),
@@ -138,77 +137,59 @@ const toBulkTrashBody = (input: TrashBulkInput) => {
 export const listTrash = (
   query: TrashListQuery = {},
 ): Effect.Effect<TrashListResponse, ListTrashError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(TrashListQuerySchema)(query).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedQuery) =>
-      requestJson(TrashListEnvelopeSchema, {
-        method: "GET",
-        path: "/v2/trash/list",
-        query: decodedQuery,
-      }),
-    ),
-    withOperationErrors(ListTrashErrorSpec),
-  );
+  decodeAndRun(TrashListQuerySchema, query, (decodedQuery) =>
+    requestJson(TrashListEnvelopeSchema, {
+      method: "GET",
+      path: "/v2/trash/list",
+      query: decodedQuery,
+    }),
+  ).pipe(withOperationErrors(ListTrashErrorSpec));
 
 export const continueTrash = (
   cursor: string,
   query: TrashListQuery = {},
 ): Effect.Effect<TrashContinueResponse, ContinueTrashError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(TrashContinueInputSchema)({ cursor, query }).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedInput) =>
-      requestJson(TrashContinueEnvelopeSchema, {
-        body: {
-          type: "form",
-          value: {
-            cursor: decodedInput.cursor,
-          },
+  decodeAndRun(TrashContinueInputSchema, { cursor, query }, (decodedInput) =>
+    requestJson(TrashContinueEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: {
+          cursor: decodedInput.cursor,
         },
-        method: "POST",
-        path: "/v2/trash/list/continue",
-        query: decodedInput.query,
-      }),
-    ),
-    withOperationErrors(ContinueTrashErrorSpec),
-  );
+      },
+      method: "POST",
+      path: "/v2/trash/list/continue",
+      query: decodedInput.query,
+    }),
+  ).pipe(withOperationErrors(ContinueTrashErrorSpec));
 
 export const restoreTrash = (
   input: TrashBulkInput,
 ): Effect.Effect<void, RestoreTrashError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(TrashBulkInputSchema)(input).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedInput) =>
-      requestJson(OkResponseSchema, {
-        body: {
-          type: "form",
-          value: toBulkTrashBody(decodedInput),
-        },
-        method: "POST",
-        path: "/v2/trash/restore",
-      }),
-    ),
-    Effect.asVoid,
-    withOperationErrors(RestoreTrashErrorSpec),
-  );
+  decodeAndRun(TrashBulkInputSchema, input, (decodedInput) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value: toBulkTrashBody(decodedInput),
+      },
+      method: "POST",
+      path: "/v2/trash/restore",
+    }),
+  ).pipe(Effect.asVoid, withOperationErrors(RestoreTrashErrorSpec));
 
 export const deleteTrash = (
   input: TrashBulkInput,
 ): Effect.Effect<void, DeleteTrashError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(TrashBulkInputSchema)(input).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedInput) =>
-      requestJson(OkResponseSchema, {
-        body: {
-          type: "form",
-          value: toBulkTrashBody(decodedInput),
-        },
-        method: "POST",
-        path: "/v2/trash/delete",
-      }),
-    ),
-    Effect.asVoid,
-    withOperationErrors(DeleteTrashErrorSpec),
-  );
+  decodeAndRun(TrashBulkInputSchema, input, (decodedInput) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value: toBulkTrashBody(decodedInput),
+      },
+      method: "POST",
+      path: "/v2/trash/delete",
+    }),
+  ).pipe(Effect.asVoid, withOperationErrors(DeleteTrashErrorSpec));
 
 export const emptyTrash = (): Effect.Effect<void, EmptyTrashError, PutioSdkContext> =>
   requestJson(OkResponseSchema, {

--- a/src/domains/trash.ts
+++ b/src/domains/trash.ts
@@ -1,14 +1,14 @@
 import { Effect, Schema } from "effect";
 
 import { joinCsv } from "../core/forms.js";
-import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
+import { NonEmptyStringSchema, PositiveIntegerSchema, decodeAndRun } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
 import { FileTypeSchema } from "./files.js";
-import { OkResponseSchema, decodeAndRun, requestJson, type PutioSdkContext } from "../core/http.js";
+import { OkResponseSchema, requestJson, type PutioSdkContext } from "../core/http.js";
 
 export const TrashFileSchema = Schema.Struct({
   content_type: Schema.NullOr(Schema.String),

--- a/src/domains/zips.ts
+++ b/src/domains/zips.ts
@@ -1,6 +1,10 @@
 import { Effect, Schema } from "effect";
 import { toCursorSelectionForm } from "../core/forms.js";
-import { PositiveIntegerSchema, makeCursorSelectionSchema } from "../core/validation.js";
+import {
+  PositiveIntegerSchema,
+  decodeAndRun,
+  makeCursorSelectionSchema,
+} from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   withOperationErrors,
@@ -8,7 +12,6 @@ import {
 } from "../core/errors.js";
 import {
   OkResponseSchema,
-  decodeAndRun,
   encodePathSegment,
   requestJson,
   selectJsonField,

--- a/src/domains/zips.ts
+++ b/src/domains/zips.ts
@@ -1,5 +1,6 @@
 import { Effect, Schema } from "effect";
 import { toCursorSelectionForm } from "../core/forms.js";
+import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   mapDecodeErrorToValidationError,
@@ -13,8 +14,6 @@ import {
   selectJsonField,
   type PutioSdkContext,
 } from "../core/http.js";
-const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
-const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));
 export const ZipStatusSchema = Schema.Literals(["NEW", "PROCESSING", "DONE", "ERROR"]);
 const ZipSummarySchema = Schema.Struct({
   created_at: Schema.String,
@@ -58,8 +57,8 @@ export type ZipCreateResponse = Schema.Schema.Type<typeof ZipCreateEnvelopeSchem
 export type ZipInfo = Schema.Schema.Type<typeof ZipInfoSchema>;
 const CreateZipInputSchema = Schema.Struct({
   cursor: Schema.optional(NonEmptyStringSchema),
-  exclude_ids: Schema.optional(Schema.Array(PositiveIdSchema)),
-  file_ids: Schema.optional(Schema.Array(PositiveIdSchema).check(Schema.isMinLength(1))),
+  exclude_ids: Schema.optional(Schema.Array(PositiveIntegerSchema)),
+  file_ids: Schema.optional(Schema.Array(PositiveIntegerSchema).check(Schema.isMinLength(1))),
 }).check(
   Schema.makeFilter((input) => input.cursor !== undefined || input.file_ids !== undefined, {
     expected: "a non-empty cursor or file ID selection",
@@ -143,7 +142,7 @@ export const createZip = (
     withOperationErrors(CreateZipErrorSpec),
   );
 export const getZip = (id: number): Effect.Effect<ZipInfo, GetZipError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(ZipInfoSchema, {
@@ -154,7 +153,7 @@ export const getZip = (id: number): Effect.Effect<ZipInfo, GetZipError, PutioSdk
     withOperationErrors(GetZipErrorSpec),
   );
 export const cancelZip = (id: number): Effect.Effect<void, CancelZipError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap((decodedId) =>
       requestJson(OkResponseSchema, {

--- a/src/domains/zips.ts
+++ b/src/domains/zips.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from "effect";
 import { toCursorSelectionForm } from "../core/forms.js";
 import {
   definePutioOperationErrorSpec,
+  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
@@ -12,6 +13,8 @@ import {
   selectJsonField,
   type PutioSdkContext,
 } from "../core/http.js";
+const PositiveIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
+const NonEmptyStringSchema = Schema.String.check(Schema.isMinLength(1));
 export const ZipStatusSchema = Schema.Literals(["NEW", "PROCESSING", "DONE", "ERROR"]);
 const ZipSummarySchema = Schema.Struct({
   created_at: Schema.String,
@@ -53,11 +56,16 @@ const ZipInfoSchema = Schema.Union([ZipInfoPendingSchema, ZipInfoErrorSchema, Zi
 export type ZipSummary = Schema.Schema.Type<typeof ZipSummarySchema>;
 export type ZipCreateResponse = Schema.Schema.Type<typeof ZipCreateEnvelopeSchema>;
 export type ZipInfo = Schema.Schema.Type<typeof ZipInfoSchema>;
-export type CreateZipInput = {
-  readonly cursor?: string;
-  readonly exclude_ids?: ReadonlyArray<number>;
-  readonly file_ids?: ReadonlyArray<number>;
-};
+const CreateZipInputSchema = Schema.Struct({
+  cursor: Schema.optional(NonEmptyStringSchema),
+  exclude_ids: Schema.optional(Schema.Array(PositiveIdSchema)),
+  file_ids: Schema.optional(Schema.Array(PositiveIdSchema).check(Schema.isMinLength(1))),
+}).check(
+  Schema.makeFilter((input) => input.cursor !== undefined || input.file_ids !== undefined, {
+    expected: "a non-empty cursor or file ID selection",
+  }),
+);
+export type CreateZipInput = Schema.Schema.Type<typeof CreateZipInputSchema>;
 const FilesReadScopeError = { errorType: "invalid_scope", statusCode: 401 as const };
 const FilesWriteScopeError = { errorType: "invalid_scope", statusCode: 401 as const };
 export const ListZipsErrorSpec = definePutioOperationErrorSpec({
@@ -113,27 +121,47 @@ export const listZips = (): Effect.Effect<
 export const createZip = (
   input: CreateZipInput,
 ): Effect.Effect<number, CreateZipError, PutioSdkContext> =>
-  requestJson(ZipCreateEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: {
-        ...toCursorSelectionForm({
-          cursor: input.cursor,
-          excludeIds: input.exclude_ids,
-          ids: input.file_ids,
-        }),
-      },
-    },
-    method: "POST",
-    path: "/v2/zips/create",
-  }).pipe(selectJsonField("zip_id"), withOperationErrors(CreateZipErrorSpec));
+  Schema.decodeUnknownEffect(CreateZipInputSchema)(input).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInput) =>
+      requestJson(ZipCreateEnvelopeSchema, {
+        body: {
+          type: "form",
+          value: {
+            ...toCursorSelectionForm({
+              cursor: decodedInput.cursor,
+              excludeIds: decodedInput.exclude_ids,
+              ids: decodedInput.file_ids,
+            }),
+          },
+        },
+        method: "POST",
+        path: "/v2/zips/create",
+      }),
+    ),
+    selectJsonField("zip_id"),
+    withOperationErrors(CreateZipErrorSpec),
+  );
 export const getZip = (id: number): Effect.Effect<ZipInfo, GetZipError, PutioSdkContext> =>
-  requestJson(ZipInfoSchema, {
-    method: "GET",
-    path: `/v2/zips/${encodePathSegment(id)}`,
-  }).pipe(withOperationErrors(GetZipErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(ZipInfoSchema, {
+        method: "GET",
+        path: `/v2/zips/${encodePathSegment(decodedId)}`,
+      }),
+    ),
+    withOperationErrors(GetZipErrorSpec),
+  );
 export const cancelZip = (id: number): Effect.Effect<void, CancelZipError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    method: "GET",
-    path: `/v2/zips/${encodePathSegment(id)}/cancel`,
-  }).pipe(Effect.asVoid, withOperationErrors(CancelZipErrorSpec));
+  Schema.decodeUnknownEffect(PositiveIdSchema)(id).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedId) =>
+      requestJson(OkResponseSchema, {
+        method: "GET",
+        path: `/v2/zips/${encodePathSegment(decodedId)}/cancel`,
+      }),
+    ),
+    Effect.asVoid,
+    withOperationErrors(CancelZipErrorSpec),
+  );

--- a/src/domains/zips.ts
+++ b/src/domains/zips.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema } from "effect";
 import { toCursorSelectionForm } from "../core/forms.js";
-import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
+import { PositiveIntegerSchema, makeCursorSelectionSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
   mapDecodeErrorToValidationError,
@@ -55,15 +55,7 @@ const ZipInfoSchema = Schema.Union([ZipInfoPendingSchema, ZipInfoErrorSchema, Zi
 export type ZipSummary = Schema.Schema.Type<typeof ZipSummarySchema>;
 export type ZipCreateResponse = Schema.Schema.Type<typeof ZipCreateEnvelopeSchema>;
 export type ZipInfo = Schema.Schema.Type<typeof ZipInfoSchema>;
-const CreateZipInputSchema = Schema.Struct({
-  cursor: Schema.optional(NonEmptyStringSchema),
-  exclude_ids: Schema.optional(Schema.Array(PositiveIntegerSchema)),
-  file_ids: Schema.optional(Schema.Array(PositiveIntegerSchema).check(Schema.isMinLength(1))),
-}).check(
-  Schema.makeFilter((input) => input.cursor !== undefined || input.file_ids !== undefined, {
-    expected: "a non-empty cursor or file ID selection",
-  }),
-);
+const CreateZipInputSchema = makeCursorSelectionSchema("file_ids", "exclude_ids");
 export type CreateZipInput = Schema.Schema.Type<typeof CreateZipInputSchema>;
 const FilesReadScopeError = { errorType: "invalid_scope", statusCode: 401 as const };
 const FilesWriteScopeError = { errorType: "invalid_scope", statusCode: 401 as const };

--- a/src/domains/zips.ts
+++ b/src/domains/zips.ts
@@ -3,12 +3,12 @@ import { toCursorSelectionForm } from "../core/forms.js";
 import { PositiveIntegerSchema, makeCursorSelectionSchema } from "../core/validation.js";
 import {
   definePutioOperationErrorSpec,
-  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
 import {
   OkResponseSchema,
+  decodeAndRun,
   encodePathSegment,
   requestJson,
   selectJsonField,
@@ -112,47 +112,33 @@ export const listZips = (): Effect.Effect<
 export const createZip = (
   input: CreateZipInput,
 ): Effect.Effect<number, CreateZipError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(CreateZipInputSchema)(input).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedInput) =>
-      requestJson(ZipCreateEnvelopeSchema, {
-        body: {
-          type: "form",
-          value: {
-            ...toCursorSelectionForm({
-              cursor: decodedInput.cursor,
-              excludeIds: decodedInput.exclude_ids,
-              ids: decodedInput.file_ids,
-            }),
-          },
+  decodeAndRun(CreateZipInputSchema, input, (decodedInput) =>
+    requestJson(ZipCreateEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: {
+          ...toCursorSelectionForm({
+            cursor: decodedInput.cursor,
+            excludeIds: decodedInput.exclude_ids,
+            ids: decodedInput.file_ids,
+          }),
         },
-        method: "POST",
-        path: "/v2/zips/create",
-      }),
-    ),
-    selectJsonField("zip_id"),
-    withOperationErrors(CreateZipErrorSpec),
-  );
+      },
+      method: "POST",
+      path: "/v2/zips/create",
+    }),
+  ).pipe(selectJsonField("zip_id"), withOperationErrors(CreateZipErrorSpec));
 export const getZip = (id: number): Effect.Effect<ZipInfo, GetZipError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedId) =>
-      requestJson(ZipInfoSchema, {
-        method: "GET",
-        path: `/v2/zips/${encodePathSegment(decodedId)}`,
-      }),
-    ),
-    withOperationErrors(GetZipErrorSpec),
-  );
+  decodeAndRun(PositiveIntegerSchema, id, (decodedId) =>
+    requestJson(ZipInfoSchema, {
+      method: "GET",
+      path: `/v2/zips/${encodePathSegment(decodedId)}`,
+    }),
+  ).pipe(withOperationErrors(GetZipErrorSpec));
 export const cancelZip = (id: number): Effect.Effect<void, CancelZipError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(PositiveIntegerSchema)(id).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedId) =>
-      requestJson(OkResponseSchema, {
-        method: "GET",
-        path: `/v2/zips/${encodePathSegment(decodedId)}/cancel`,
-      }),
-    ),
-    Effect.asVoid,
-    withOperationErrors(CancelZipErrorSpec),
-  );
+  decodeAndRun(PositiveIntegerSchema, id, (decodedId) =>
+    requestJson(OkResponseSchema, {
+      method: "GET",
+      path: `/v2/zips/${encodePathSegment(decodedId)}/cancel`,
+    }),
+  ).pipe(Effect.asVoid, withOperationErrors(CancelZipErrorSpec));

--- a/test/live/domains/zips.ts
+++ b/test/live/domains/zips.ts
@@ -11,7 +11,7 @@ const { authClient, oauthClient } = await createClients({
 });
 
 const live = createLiveHarness("zips live");
-const { assert, assertOperationError, finish, run, sleep } = live;
+const { assert, assertErrorTag, assertOperationError, finish, run, sleep } = live;
 
 void assertOperationError;
 void sleep;
@@ -129,18 +129,14 @@ await run("zips list shape", async () => {
   };
 });
 
-await run("zips create empty payload yields 400", async () => {
+await run("zips create empty payload fails validation", async () => {
   try {
     await authClient.zips.create({
       file_ids: [],
     });
     throw new Error("expected empty zip payload to fail");
   } catch (error) {
-    return assertOperationError(error, {
-      domain: "zips",
-      operation: "create",
-      statusCode: 400,
-    });
+    return assertErrorTag(error, { tag: "PutioValidationError" });
   }
 });
 


### PR DESCRIPTION
## Summary

Validate trash pagination/bulk operations and zip selections before query, form, or path serialization.

## Changed

- Decode trash list/continue inputs and validate positive page sizes plus non-empty cursors.
- Replace the trash bulk synchronous throw with a schema-decoded `PutioValidationError` Effect.
- Make cursor bulk mode explicit with `useCursor: true`; file-ID mode requires a non-empty positive-ID array.
- Validate zip creation requires a non-empty cursor or positive file-ID selection, and validate positive zip IDs.
- Cover 20 malformed runtime inputs with zero transport calls.

## Review aids

```mermaid
flowchart LR
  A["trash or zip runtime input"] --> B["Effect Schema decode"]
  B -->|valid| C["existing CSV, form, query, or path serializer"]
  C --> D["API request"]
  B -->|invalid| E["PutioValidationError"]
  E --> F["zero transport calls"]
```

The existing operational-domain test remains the positive reference for trash pagination, ID/cursor bulk bodies, zip CSV selection, and zip paths.

## Risks

- `TrashBulkInput` now requires `useCursor: true` for cursor mode. The previous `{ cursor }` shape was type-accepted but always threw synchronously at runtime.
- Empty selections, zero IDs, empty cursors, and non-positive page sizes now fail locally.
- Successful request/response contracts are unchanged.

## Verification

- `pnpm exec vp run verify` — 19 files, 97 tests, 98.62% statements
- `pnpm exec vp run lint:package`
- `pnpm exec vp run test:compat` — Node, Chromium, Firefox, WebKit, Bun

## Complexity

Moderate. This replaces one unsound hand-written union/throw boundary and wraps existing serializers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict, schema-based validation to trash, zip, and related domains, centralizing input decoding with an internal `decodeAndRun` and shared `makeCursorSelectionSchema`. Invalid inputs are rejected locally as `PutioValidationError` with zero network calls across `trash`, `zips`, `download-links`, `events`, `rss`, and `sharing`.

- **Bug Fixes**
  - Trash list/continue: validate `per_page > 0` and non-empty `cursor`; both use `decodeAndRun`.
  - Trash bulk restore/delete: enforce exclusive selectors — `useCursor: true` with non-empty `cursor` and no `file_ids`, or positive `file_ids` with no `cursor`; reject mixed inputs before transport.
  - Zips: `create` requires a non-empty `cursor` or positive `file_ids`; `exclude_ids` must be positive; `getZip`/`cancelZip` require positive IDs; all validated via `decodeAndRun`.
  - Shared schemas: apply `PositiveIntegerSchema`, `NonEmptyStringSchema`, and `makeCursorSelectionSchema` across `download-links`, `events`, `rss`, and `sharing`; map decode errors to `PutioValidationError`.
  - Tests: unit covers invalid trash/zip inputs with zero requests; live zip empty input now fails locally.

- **Migration**
  - Pass valid `per_page` and non-empty `cursor` where required.
  - For trash restore/delete, choose one mode: `useCursor: true` with a non-empty `cursor`, or non-empty positive `file_ids`. Do not mix selectors.
  - For `zips.createZip`, supply a non-empty `cursor` or non-empty `file_ids`; `exclude_ids` must be positive integers.

<sup>Written for commit 656d5ea7830363972f6a1ba300cb8f051d972c54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

