### PR TITLE
fix(sdk): validate family and friends paths

### DIFF
--- a/src/domains/family.ts
+++ b/src/domains/family.ts
@@ -1,9 +1,11 @@
 import { Effect, Schema } from "effect";
 import {
   definePutioOperationErrorSpec,
+  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
+import { NonEmptyStringSchema } from "../core/validation.js";
 import {
   OkResponseSchema,
   encodePathSegment,
@@ -133,14 +135,28 @@ export const createFamilyInvite = (): Effect.Effect<
 export const removeFamilyMember = (
   username: string,
 ): Effect.Effect<void, RemoveFamilyMemberError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    method: "DELETE",
-    path: `/v2/family/sub_account/${encodePathSegment(username)}`,
-  }).pipe(Effect.asVoid, withOperationErrors(RemoveFamilyMemberErrorSpec));
+  Schema.decodeUnknownEffect(NonEmptyStringSchema)(username).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedUsername) =>
+      requestJson(OkResponseSchema, {
+        method: "DELETE",
+        path: `/v2/family/sub_account/${encodePathSegment(decodedUsername)}`,
+      }),
+    ),
+    Effect.asVoid,
+    withOperationErrors(RemoveFamilyMemberErrorSpec),
+  );
 export const joinFamily = (
   inviteCode: string,
 ): Effect.Effect<void, JoinFamilyError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/family/join/${encodePathSegment(inviteCode)}`,
-  }).pipe(Effect.asVoid, withOperationErrors(JoinFamilyErrorSpec));
+  Schema.decodeUnknownEffect(NonEmptyStringSchema)(inviteCode).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+    Effect.flatMap((decodedInviteCode) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/family/join/${encodePathSegment(decodedInviteCode)}`,
+      }),
+    ),
+    Effect.asVoid,
+    withOperationErrors(JoinFamilyErrorSpec),
+  );

--- a/src/domains/friends.ts
+++ b/src/domains/friends.ts
@@ -1,9 +1,11 @@
 import { Effect, Schema } from "effect";
 import {
   definePutioOperationErrorSpec,
+  mapDecodeErrorToValidationError,
   withOperationErrors,
   type PutioOperationFailure,
 } from "../core/errors.js";
+import { NonEmptyStringSchema } from "../core/validation.js";
 import { FileBroadSchema, type FileBroad } from "./files.js";
 import {
   OkResponseSchema,
@@ -133,6 +135,10 @@ export type RemoveFriendError = PutioOperationFailure<typeof RemoveFriendErrorSp
 export type ApproveFriendRequestError = PutioOperationFailure<typeof ApproveFriendRequestErrorSpec>;
 export type DenyFriendRequestError = PutioOperationFailure<typeof DenyFriendRequestErrorSpec>;
 export type FriendSharedFolderError = PutioOperationFailure<typeof FriendSharedFolderErrorSpec>;
+const decodeUsername = (username: string) =>
+  Schema.decodeUnknownEffect(NonEmptyStringSchema)(username).pipe(
+    Effect.mapError(mapDecodeErrorToValidationError),
+  );
 export const listFriends = (): Effect.Effect<
   {
     readonly friends: ReadonlyArray<Friend>;
@@ -148,10 +154,16 @@ export const listFriends = (): Effect.Effect<
 export const searchFriends = (
   username: string,
 ): Effect.Effect<ReadonlyArray<UserSearchResult>, SearchFriendsError, PutioSdkContext> =>
-  requestJson(FriendSearchEnvelopeSchema, {
-    method: "GET",
-    path: `/v2/friends/user-search/${encodePathSegment(username)}`,
-  }).pipe(selectJsonField("users"), withOperationErrors(SearchFriendsErrorSpec));
+  decodeUsername(username).pipe(
+    Effect.flatMap((decodedUsername) =>
+      requestJson(FriendSearchEnvelopeSchema, {
+        method: "GET",
+        path: `/v2/friends/user-search/${encodePathSegment(decodedUsername)}`,
+      }),
+    ),
+    selectJsonField("users"),
+    withOperationErrors(SearchFriendsErrorSpec),
+  );
 export const listWaitingRequests = (): Effect.Effect<
   ReadonlyArray<FriendBase>,
   ListWaitingRequestsError,
@@ -186,17 +198,27 @@ export const sendFriendRequest = (
   SendFriendRequestError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/friends/${encodePathSegment(username)}/request`,
-  }).pipe(withOperationErrors(SendFriendRequestErrorSpec));
+  decodeUsername(username).pipe(
+    Effect.flatMap((decodedUsername) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/friends/${encodePathSegment(decodedUsername)}/request`,
+      }),
+    ),
+    withOperationErrors(SendFriendRequestErrorSpec),
+  );
 export const removeFriend = (
   username: string,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, RemoveFriendError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/friends/${encodePathSegment(username)}/unfriend`,
-  }).pipe(withOperationErrors(RemoveFriendErrorSpec));
+  decodeUsername(username).pipe(
+    Effect.flatMap((decodedUsername) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/friends/${encodePathSegment(decodedUsername)}/unfriend`,
+      }),
+    ),
+    withOperationErrors(RemoveFriendErrorSpec),
+  );
 export const approveFriendRequest = (
   username: string,
 ): Effect.Effect<
@@ -204,10 +226,15 @@ export const approveFriendRequest = (
   ApproveFriendRequestError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/friends/${encodePathSegment(username)}/approve`,
-  }).pipe(withOperationErrors(ApproveFriendRequestErrorSpec));
+  decodeUsername(username).pipe(
+    Effect.flatMap((decodedUsername) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/friends/${encodePathSegment(decodedUsername)}/approve`,
+      }),
+    ),
+    withOperationErrors(ApproveFriendRequestErrorSpec),
+  );
 export const denyFriendRequest = (
   username: string,
 ): Effect.Effect<
@@ -215,14 +242,25 @@ export const denyFriendRequest = (
   DenyFriendRequestError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/friends/${encodePathSegment(username)}/deny`,
-  }).pipe(withOperationErrors(DenyFriendRequestErrorSpec));
+  decodeUsername(username).pipe(
+    Effect.flatMap((decodedUsername) =>
+      requestJson(OkResponseSchema, {
+        method: "POST",
+        path: `/v2/friends/${encodePathSegment(decodedUsername)}/deny`,
+      }),
+    ),
+    withOperationErrors(DenyFriendRequestErrorSpec),
+  );
 export const getFriendSharedFolder = (
   username: string,
 ): Effect.Effect<FileBroad | null, FriendSharedFolderError, PutioSdkContext> =>
-  requestJson(FriendSharedFolderEnvelopeSchema, {
-    method: "GET",
-    path: `/v2/friends/${encodePathSegment(username)}/files`,
-  }).pipe(selectJsonField("file"), withOperationErrors(FriendSharedFolderErrorSpec));
+  decodeUsername(username).pipe(
+    Effect.flatMap((decodedUsername) =>
+      requestJson(FriendSharedFolderEnvelopeSchema, {
+        method: "GET",
+        path: `/v2/friends/${encodePathSegment(decodedUsername)}/files`,
+      }),
+    ),
+    selectJsonField("file"),
+    withOperationErrors(FriendSharedFolderErrorSpec),
+  );

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -651,13 +651,21 @@ describe("supporting domain boundaries", () => {
 
     await runSdkEffect(
       family.removeFamilyMember("sdk user"),
-      () => jsonResponse({ status: "OK" }),
+      (request) => {
+        expect(request.url).toBe("https://api.put.io/v2/family/sub_account/sdk%20user");
+        return jsonResponse({ status: "OK" });
+      },
       { accessToken: "token-123" },
     );
 
-    await runSdkEffect(family.joinFamily("family-code"), () => jsonResponse({ status: "OK" }), {
-      accessToken: "token-123",
-    });
+    await runSdkEffect(
+      family.joinFamily("family/code"),
+      (request) => {
+        expect(request.url).toBe("https://api.put.io/v2/family/join/family%2Fcode");
+        return jsonResponse({ status: "OK" });
+      },
+      { accessToken: "token-123" },
+    );
 
     expect(
       await runSdkEffect(
@@ -805,6 +813,35 @@ describe("supporting domain boundaries", () => {
         { accessToken: "token-123" },
       ),
     ).toMatchObject({ id: 7 });
+  });
+
+  it("rejects invalid family and friends requests before transport", async () => {
+    let requestCount = 0;
+    const invalidHandler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+
+    const failures = await Promise.all([
+      runSdkExit(family.removeFamilyMember(""), invalidHandler),
+      runSdkExit(family.joinFamily(""), invalidHandler),
+      runSdkExit(friends.searchFriends(""), invalidHandler),
+      runSdkExit(friends.sendFriendRequest(""), invalidHandler),
+      runSdkExit(friends.removeFriend(""), invalidHandler),
+      runSdkExit(friends.approveFriendRequest(""), invalidHandler),
+      runSdkExit(friends.denyFriendRequest(""), invalidHandler),
+      runSdkExit(friends.getFriendSharedFolder(""), invalidHandler),
+      runSdkExit(
+        // @ts-expect-error JavaScript callers can supply non-string usernames.
+        friends.searchFriends(null),
+        invalidHandler,
+      ),
+    ]);
+
+    expect(
+      failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
+    expect(requestCount).toBe(0);
   });
 
   it("covers ifttt and tunnel routes", async () => {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates friends usernames and family invite codes before building request paths. Invalid or empty inputs now return `PutioValidationError`, and no network calls are made.

- **Bug Fixes**
  - Added non-empty string validation to `searchFriends`, `sendFriendRequest`, `removeFriend`, `approveFriendRequest`, `denyFriendRequest`, and `getFriendSharedFolder`.
  - Applied the same validation to `family.removeFamilyMember` and `family.joinFamily`.
  - Centralized friends username validation via `decodeUsername` using `NonEmptyStringSchema`, mapping errors with `mapDecodeErrorToValidationError`.
  - Updated tests to verify URL encoding for spaces and slashes, and ensure invalid or non-string inputs never trigger requests.

<sup>Written for commit 957c19b669828dfcb086b8bfe88a7e3ee8977c76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

