### PR TITLE
ci: add unattended agent verification lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Live SDK verification env file.
 # Copy this to `.env` or `.env.local` and fill only the values needed by the live targets you run.
 
+# Infisical coordinates for local setup or a runner-injected machine identity.
+# Keep INFISICAL_TOKEN in the runner environment, never in this file.
+PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_ID=""
+PUTIO_SDK_TYPESCRIPT_INFISICAL_PATH=""
+PUTIO_SDK_TYPESCRIPT_INFISICAL_ENV="dev"
+PUTIO_INFISICAL_DOMAIN="https://eu.infisical.com/api"
+
 # Bootstrap creds — used by `bootstrap:tokens` and credential live tests to mint fresh tokens.
 PUTIO_TEST_USERNAME=""
 PUTIO_TEST_PASSWORD=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       cancel-in-progress: true
     permissions:
       contents: read
+    env:
+      AGENT_ATTEMPT_ID: verify-${{ github.run_attempt }}
+      AGENT_TASK_CLASS: implementation
+      AGENT_TASK_ID: github-${{ github.run_id }}
 
     steps:
       - name: Check out repository
@@ -33,14 +37,17 @@ jobs:
           node-version-file: ".node-version"
           cache: true
 
-      - name: Install dependencies
-        run: vp install
+      - name: Run agent lifecycle
+        run: ./scripts/agent-run.sh
 
-      - name: Verify repository
-        run: vp run verify
-
-      - name: Verify package metadata
-        run: vp run lint:package
+      - name: Upload agent evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: agent-readiness-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/agent-readiness
+          if-no-files-found: error
+          retention-days: 14
 
   compatibility:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.artifacts
 .env
 .env.*
 !.env.example

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,3 +1,1 @@
-/.env
-/.env.local
 /.repos/effect/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Install the pinned dependencies without changing machine-global tooling:
 
 ```bash
 pnpm install --frozen-lockfile
+pnpm exec vp config
 ```
 
 ## Validation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,10 @@ Thanks for contributing to `@putdotio/sdk`.
 
 ## Setup
 
-Install dependencies with Vite+:
+Install the pinned dependencies without changing machine-global tooling:
 
 ```bash
-vp install
-```
-
-Then install the stock Vite+ hook wiring for this clone:
-
-```bash
-vp config
+pnpm install --frozen-lockfile
 ```
 
 ## Validation
@@ -21,14 +15,14 @@ vp config
 Run the full repo guardrail before opening or updating a pull request:
 
 ```bash
-vp run verify
+pnpm exec vp run verify
 ```
 
 That command runs formatting, linting, package build, unit tests, and coverage using the same repo-local entrypoint CI relies on.
 
 The coverage guardrail is unit-only and counts all production files under `src/**`.
 Live tests are separate confidence checks outside the coverage threshold.
-Package-surface verification runs in CI through `vp run lint:package`.
+Package-surface verification runs in CI through `pnpm exec vp run lint:package`.
 
 ## Live Verification
 
@@ -43,13 +37,13 @@ cp .env.example .env
 Run the full live suite:
 
 ```bash
-vp run test:live
+pnpm exec vp run test:live
 ```
 
 Run the package-surface checks:
 
 ```bash
-vp run lint:package
+pnpm exec vp run lint:package
 ```
 
 The package-surface checks do not require live credentials. Use live tests when you need backend sanity checks, release confidence, or verification for stateful flows that unit tests cannot prove.
@@ -71,7 +65,7 @@ For single-target commands, safety rules, and fixture expectations, see [Testing
 
 ## Development Notes
 
-- Prefer `vp` for repo commands.
+- Use `pnpm exec vp` for direct Vite+ commands; package scripts can use their pinned `vp` binary.
 - Treat `@putdotio/sdk` as a new public package, not a compatibility wrapper around `putio-js`.
 - Keep the public surface domain-first and Effect-first.
 - Put end-user usage in [Overview](./README.md). Put deeper contributor and architecture notes in `docs/*`.

--- a/docs/READINESS.md
+++ b/docs/READINESS.md
@@ -16,11 +16,32 @@ Readiness here is based on four things:
 - live coverage exists for every implemented domain
 - the route audit has confirmed both missing operations and contract drift
 
+## Automation Contract
+
+The repository exposes one unattended lifecycle for implementation and package
+QA:
+
+1. `./scripts/agent-bootstrap.sh` validates task identity, runner versions, frozen
+   dependency setup, and the pinned Effect research checkout
+2. `./scripts/agent-verify.sh` runs the canonical deterministic and package-surface gates
+3. `./scripts/agent-teardown.sh` records the terminal status on success or failure
+4. `./scripts/agent-run.sh` composes all three and guarantees teardown
+
+CI runs the same lifecycle and retains the machine-readable evidence bundle.
+Safe scripted live QA uses `./scripts/agent-live-test.sh <explicit targets>` with direct
+runner secret injection or a scoped Infisical machine-identity token. Human
+login, profile switching, copied env files, and implicit full-suite selection
+are outside that unattended contract.
+
+The dependable scope is implementation, packed-package QA, and explicitly
+selected safe live targets. The full mutation-heavy live suite still requires
+fixture-aware scheduling because concurrent runs share account state and quotas.
+
 ## Public Route Matrix
 
 [`api-route-matrix.json`](./api-route-matrix.json) records method-level backend evidence and one
 of four decisions for each audited public route: `sdk`, `equivalent`, `excluded`, or
-`investigate`. `vp run verify` validates its shape, rejects internal or duplicate routes, and
+`investigate`. `pnpm exec vp run verify` validates its shape, rejects internal or duplicate routes, and
 checks every named operation on both Effect and Promise clients.
 
 The matrix is currently an audited seed, not a completeness claim. Every route in the seed has a

--- a/docs/READINESS.md
+++ b/docs/READINESS.md
@@ -21,8 +21,8 @@ Readiness here is based on four things:
 The repository exposes one unattended lifecycle for implementation and package
 QA:
 
-1. `./scripts/agent-bootstrap.sh` validates task identity, runner versions, frozen
-   dependency setup, and the pinned Effect research checkout
+1. `./scripts/agent-bootstrap.sh` validates task identity, pinned Node/package-tool
+   versions, frozen dependency setup, and the pinned Effect research checkout
 2. `./scripts/agent-verify.sh` runs the canonical deterministic and package-surface gates
 3. `./scripts/agent-teardown.sh` records the terminal status on success or failure
 4. `./scripts/agent-run.sh` composes all three and guarantees teardown

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,7 +22,7 @@ The live verification layer lives in:
 - `test/live/domains/*.ts`
 - `test/live/support/*`
 
-Live tests execute the built SDK from `dist/**`, so direct live targets should always run after `vp pack`.
+Live tests execute the built SDK from `dist/**`, so direct live targets should always run after `pnpm exec vp pack`.
 
 ## Local Checks
 
@@ -31,26 +31,47 @@ Default test runs intentionally exclude `test/live/**`.
 Run:
 
 ```bash
-vp install
-vp check .
-vp pack
-vp test
-vp test --coverage
+pnpm install --frozen-lockfile
+pnpm exec vp check .
+pnpm exec vp pack
+pnpm exec vp test
+pnpm exec vp test --coverage
 ```
 
 Additional package and cleanup checks:
 
 ```bash
-vp run lint:unused
-vp run lint:unused:prod
-vp run lint:package
-vp run test:compat
+pnpm exec vp run lint:unused
+pnpm exec vp run lint:unused:prod
+pnpm exec vp run lint:package
+pnpm exec vp run test:compat
 ```
 
 `lint:unused` runs Knip against source, tests, live tests, scripts, and config files to detect unused files, dependencies, and exports.
 `lint:unused:prod` packs the package, then runs Knip's production-only graph with ignored build output visible. Knip's explicit entry and project patterns keep that analysis limited to the package, tests, scripts, and root config rather than unrelated ignored files.
 `lint:package` packs the package and runs `publint` plus Are The Types Wrong against the published ESM entrypoints.
-`vp run verify` blocks on both Knip graphs and executes the covered unit suite once. CI follows it with `lint:package`; Knip governs source reachability and dependency usage, while package checks and explicit API/type tests govern intentional public exports.
+`pnpm exec vp run verify` blocks on both Knip graphs and executes the covered unit suite once. CI follows it with `lint:package`; Knip governs source reachability and dependency usage, while package checks and explicit API/type tests govern intentional public exports.
+
+## Unattended Agent Lifecycle
+
+The checked-in lifecycle requires stable task and attempt identifiers, validates
+the pinned Node.js and pnpm versions, installs from the frozen lockfile, runs the
+canonical repository and package gates, and always records teardown:
+
+```bash
+export AGENT_TASK_ID="issue-123"
+export AGENT_ATTEMPT_ID="attempt-1"
+./scripts/agent-run.sh
+```
+
+Evidence is written with mode `0600` under
+`.artifacts/agent-readiness/<task>/<attempt>/`. Each JSON record includes the
+source revision, runner, duration, result, retry count, and failure class. CI
+uses the same lifecycle and uploads the evidence bundle.
+
+Managed worktrees copy only the pinned `.repos/effect` research checkout.
+Secrets are injected by the runner or fetched per worktree; ignored env files
+are not copied automatically.
 
 ## Runtime Compatibility Checks
 
@@ -59,21 +80,21 @@ Compatibility checks are package-consumer smoke tests, not live API tests. They 
 Run all compatibility checks:
 
 ```bash
-vp run test:compat
+pnpm exec vp run test:compat
 ```
 
 Target one runtime:
 
 ```bash
-vp run test:compat:node
-PUTIO_COMPAT_BROWSERS=chromium vp run test:compat:browser
-vp run test:compat:bun
+pnpm exec vp run test:compat:node
+PUTIO_COMPAT_BROWSERS=chromium pnpm exec vp run test:compat:browser
+pnpm exec vp run test:compat:bun
 ```
 
 The browser check uses Playwright. Install local browser engines once when needed:
 
 ```bash
-vp run test:compat:browser:install
+pnpm exec vp run test:compat:browser:install
 ```
 
 The compatibility layer proves:
@@ -92,7 +113,7 @@ Unit coverage now includes all production code under `src/**`, including:
 - `src/utilities/*`
 - barrel entrypoints such as `src/index.ts` and `src/utilities.ts`
 
-`vp run verify` enforces the repo coverage floor through the unit suite only.
+`pnpm exec vp run verify` enforces the repo coverage floor through the unit suite only.
 Live tests stay separate on purpose:
 
 - they stay outside the coverage report
@@ -174,13 +195,13 @@ Keep token values out of command output, docs, comments, and commits.
 Full live suite:
 
 ```bash
-vp run test:live
+pnpm exec vp run test:live
 ```
 
 Single target:
 
 ```bash
-vp pack && vp test run --config vitest.live.config.ts test/live/auth.test.ts
+pnpm exec vp pack && pnpm exec vp test run --config vitest.live.config.ts test/live/auth.test.ts
 ```
 
 Run `pnpm secrets:setup` once per worktree to materialize `.env.local` from the
@@ -199,6 +220,39 @@ pnpm secrets:clean        # before `git worktree remove`
 `secrets:setup` requires the Infisical CLI and access to the put.io frontend
 Development environment. You can copy `.env.example` manually when using your
 own live credentials, and unit tests do not require live credentials.
+
+### Unattended live targets
+
+For unattended live verification, the runner must inject a live token pair or
+the first-party bootstrap credential set directly, or inject an
+`INFISICAL_TOKEN` machine-identity access token plus the repo-specific
+`PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_ID` and
+`PUTIO_SDK_TYPESCRIPT_INFISICAL_PATH` coordinates. The repository does not log
+in, switch a human profile, or persist fetched secrets.
+
+```bash
+export AGENT_TASK_ID="live-contract-123"
+export AGENT_ATTEMPT_ID="attempt-1"
+export AGENT_TASK_CLASS="scripted-qa"
+./scripts/agent-live-test.sh test/live/tunnel.test.ts
+```
+
+Targets that need ordinary first- and third-party tokens can bootstrap them
+ephemerally from the injected credential set. Values exist only in the test
+child process and are never printed or written to an env file. The fresh
+first-party session is revoked after success or failure:
+
+```bash
+AGENT_LIVE_REFRESH_TOKENS=1 ./scripts/agent-live-test.sh \
+  test/live/account.test.ts \
+  test/live/tunnel.test.ts
+```
+
+The unattended command requires explicit `test/live/*.test.ts` targets so a
+runner cannot accidentally select the mutation-heavy full suite. Its evidence
+log is checked against injected secret values before the result is accepted.
+Missing identity fails as `runner/missing_identity` with status 2 and an
+inspectable result record.
 
 `bootstrap:live-fixtures` validates and seeds the live fixtures that are safe to
 prepare through the public SDK. It establishes the secondary friendship/shared

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -55,8 +55,10 @@ pnpm exec vp run test:compat
 ## Unattended Agent Lifecycle
 
 The checked-in lifecycle requires stable task and attempt identifiers, validates
-the pinned Node.js and pnpm versions, installs from the frozen lockfile, runs the
-canonical repository and package gates, and always records teardown:
+the pinned Node.js and package-tool versions, installs from the frozen lockfile,
+runs the canonical repository and package gates, and always records teardown.
+It accepts the exact pnpm version used by contributors or the exact Vite+ version
+installed by the repository's CI setup action:
 
 ```bash
 export AGENT_TASK_ID="issue-123"

--- a/knip.json
+++ b/knip.json
@@ -11,5 +11,6 @@
     "vitest.live.config.ts"
   ],
   "project": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts", "*.config.ts"],
+  "ignoreBinaries": ["infisical"],
   "ignoreDependencies": ["is-ci"]
 }

--- a/scripts/agent-bootstrap.sh
+++ b/scripts/agent-bootstrap.sh
@@ -17,7 +17,7 @@ bootstrap() {
   local expected_vp
   expected_node="$(tr -d '[:space:]' < .node-version)"
   actual_node="$(node -p 'process.versions.node')"
-  expected_pnpm="$(node -p 'JSON.parse(require("node:fs").readFileSync("package.json", "utf8")).packageManager.split("@").at(-1)')"
+  expected_pnpm="$(node -p 'JSON.parse(require("node:fs").readFileSync("package.json", "utf8")).packageManager.split("@").at(-1).split("+")[0]')"
   expected_vp="$(sed -n 's/^  vite-plus: //p' pnpm-workspace.yaml)"
 
   if [[ "$actual_node" != "$expected_node" ]]; then

--- a/scripts/agent-bootstrap.sh
+++ b/scripts/agent-bootstrap.sh
@@ -10,31 +10,53 @@ bootstrap() {
     echo "Node.js is a required runner capability. Install the version from .node-version." >&2
     return 2
   }
-  command -v pnpm >/dev/null 2>&1 || {
-    echo "pnpm is a required runner capability. Install the packageManager version from package.json." >&2
-    return 2
-  }
 
   local expected_node
   local actual_node
   local expected_pnpm
-  local actual_pnpm
+  local expected_vp
   expected_node="$(tr -d '[:space:]' < .node-version)"
   actual_node="$(node -p 'process.versions.node')"
   expected_pnpm="$(node -p 'JSON.parse(require("node:fs").readFileSync("package.json", "utf8")).packageManager.split("@").at(-1)')"
-  actual_pnpm="$(pnpm --version)"
+  expected_vp="$(sed -n 's/^  vite-plus: //p' pnpm-workspace.yaml)"
 
   if [[ "$actual_node" != "$expected_node" ]]; then
     echo "Runner Node.js mismatch: expected $expected_node, found $actual_node." >&2
     return 2
   fi
 
-  if [[ "$actual_pnpm" != "$expected_pnpm" ]]; then
-    echo "Runner pnpm mismatch: expected $expected_pnpm, found $actual_pnpm." >&2
+  if command -v pnpm >/dev/null 2>&1; then
+    local actual_pnpm
+    actual_pnpm="$(pnpm --version)"
+
+    if [[ "$actual_pnpm" != "$expected_pnpm" ]]; then
+      echo "Runner pnpm mismatch: expected $expected_pnpm, found $actual_pnpm." >&2
+      return 2
+    fi
+
+    pnpm install --frozen-lockfile
+  elif command -v vp >/dev/null 2>&1; then
+    local runner_vp
+    runner_vp="$(vp --version | sed -n '1s/^vp v//p')"
+
+    if [[ "$runner_vp" != "$expected_vp" ]]; then
+      echo "Runner Vite+ mismatch: expected $expected_vp, found ${runner_vp:-unknown}." >&2
+      return 2
+    fi
+
+    vp install --frozen-lockfile
+  else
+    echo "The runner needs pnpm $expected_pnpm or Vite+ $expected_vp." >&2
     return 2
   fi
 
-  pnpm install --frozen-lockfile
+  local installed_vp
+  installed_vp="$(agent_vp --version | sed -n '1s/^vp v//p')"
+
+  if [[ "$installed_vp" != "$expected_vp" ]]; then
+    echo "Installed Vite+ mismatch: expected $expected_vp, found ${installed_vp:-unknown}." >&2
+    return 2
+  fi
 
   if [[ -z "${CI:-}" && ! -d .repos/effect/.git ]]; then
     echo "Effect source setup did not produce .repos/effect. Rerun pnpm install after checking network access." >&2

--- a/scripts/agent-bootstrap.sh
+++ b/scripts/agent-bootstrap.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(dirname "$0")/agent-common.sh"
+
+agent_require_context
+
+bootstrap() {
+  command -v node >/dev/null 2>&1 || {
+    echo "Node.js is a required runner capability. Install the version from .node-version." >&2
+    return 2
+  }
+  command -v pnpm >/dev/null 2>&1 || {
+    echo "pnpm is a required runner capability. Install the packageManager version from package.json." >&2
+    return 2
+  }
+
+  local expected_node
+  local actual_node
+  local expected_pnpm
+  local actual_pnpm
+  expected_node="$(tr -d '[:space:]' < .node-version)"
+  actual_node="$(node -p 'process.versions.node')"
+  expected_pnpm="$(node -p 'JSON.parse(require("node:fs").readFileSync("package.json", "utf8")).packageManager.split("@").at(-1)')"
+  actual_pnpm="$(pnpm --version)"
+
+  if [[ "$actual_node" != "$expected_node" ]]; then
+    echo "Runner Node.js mismatch: expected $expected_node, found $actual_node." >&2
+    return 2
+  fi
+
+  if [[ "$actual_pnpm" != "$expected_pnpm" ]]; then
+    echo "Runner pnpm mismatch: expected $expected_pnpm, found $actual_pnpm." >&2
+    return 2
+  fi
+
+  pnpm install --frozen-lockfile
+
+  if [[ -z "${CI:-}" && ! -d .repos/effect/.git ]]; then
+    echo "Effect source setup did not produce .repos/effect. Rerun pnpm install after checking network access." >&2
+    return 1
+  fi
+
+  git diff --exit-code -- pnpm-lock.yaml
+}
+
+agent_run_logged bootstrap cold-start bootstrap/failed bootstrap

--- a/scripts/agent-common.sh
+++ b/scripts/agent-common.sh
@@ -26,6 +26,21 @@ agent_record() {
   node ./scripts/agent-record.ts "$@"
 }
 
+agent_vp() {
+  if [[ -x node_modules/.bin/vp ]]; then
+    ./node_modules/.bin/vp "$@"
+    return
+  fi
+
+  if command -v vp >/dev/null 2>&1; then
+    vp "$@"
+    return
+  fi
+
+  echo "Vite+ is unavailable. Run the agent bootstrap or use the repository's setup action." >&2
+  return 2
+}
+
 agent_run_logged() {
   local phase="$1"
   local scenario="$2"

--- a/scripts/agent-common.sh
+++ b/scripts/agent-common.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+agent_require_context() {
+  : "${AGENT_TASK_ID:?Set AGENT_TASK_ID to a stable task identifier}"
+  : "${AGENT_ATTEMPT_ID:?Set AGENT_ATTEMPT_ID to a stable attempt identifier}"
+
+  if [[ ! "$AGENT_TASK_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+    echo "AGENT_TASK_ID must use 1-128 letters, numbers, dots, underscores, or hyphens." >&2
+    return 2
+  fi
+
+  if [[ ! "$AGENT_ATTEMPT_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+    echo "AGENT_ATTEMPT_ID must use 1-128 letters, numbers, dots, underscores, or hyphens." >&2
+    return 2
+  fi
+
+  export AGENT_ARTIFACTS_DIR="${AGENT_ARTIFACTS_DIR:-.artifacts/agent-readiness}"
+  export AGENT_ATTEMPT_ARTIFACT_DIR="$AGENT_ARTIFACTS_DIR/$AGENT_TASK_ID/$AGENT_ATTEMPT_ID"
+  umask 077
+  mkdir -p "$AGENT_ATTEMPT_ARTIFACT_DIR"
+}
+
+agent_record() {
+  node ./scripts/agent-record.ts "$@"
+}
+
+agent_run_logged() {
+  local phase="$1"
+  local scenario="$2"
+  local failure_class="$3"
+  shift 3
+
+  local restore_errexit=0
+  local started_at=$SECONDS
+  local log_path="$AGENT_ATTEMPT_ARTIFACT_DIR/$phase.log"
+
+  if [[ $- == *e* ]]; then
+    restore_errexit=1
+  fi
+
+  set +e
+  "$@" 2>&1 | tee "$log_path"
+  local command_status=${PIPESTATUS[0]}
+
+  if ((restore_errexit == 1)); then
+    set -e
+  fi
+
+  local duration_seconds=$((SECONDS - started_at))
+  local result="success"
+  local recorded_failure=""
+
+  if ((command_status != 0)); then
+    result="failure"
+    recorded_failure="$failure_class"
+    if [[ "${AGENT_EXPECTED_FAILURE:-0}" == "1" ]]; then
+      result="expected_failure"
+    fi
+  fi
+
+  agent_record record "$phase" "$scenario" "$result" "$recorded_failure" \
+    "$duration_seconds" "$command_status" "$log_path"
+
+  return "$command_status"
+}

--- a/scripts/agent-common.sh
+++ b/scripts/agent-common.sh
@@ -16,6 +16,12 @@ agent_require_context() {
     return 2
   fi
 
+  export AGENT_TASK_CLASS="${AGENT_TASK_CLASS:-implementation}"
+  if [[ ! "$AGENT_TASK_CLASS" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+    echo "AGENT_TASK_CLASS must use 1-128 letters, numbers, dots, underscores, or hyphens." >&2
+    return 2
+  fi
+
   export AGENT_ARTIFACTS_DIR="${AGENT_ARTIFACTS_DIR:-.artifacts/agent-readiness}"
   export AGENT_ATTEMPT_ARTIFACT_DIR="$AGENT_ARTIFACTS_DIR/$AGENT_TASK_ID/$AGENT_ATTEMPT_ID"
   umask 077
@@ -23,7 +29,37 @@ agent_require_context() {
 }
 
 agent_record() {
-  node ./scripts/agent-record.ts "$@"
+  if command -v node >/dev/null 2>&1; then
+    node ./scripts/agent-record.ts "$@"
+    return
+  fi
+
+  local phase="$2"
+  local scenario="$3"
+  local result="$4"
+  local failure_class="$5"
+  local duration_seconds="$6"
+  local status_code="$7"
+  local captured_at
+  local failure_class_json="null"
+  local runner
+  local source_revision="unknown"
+
+  captured_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  runner="$(uname -s)-$(uname -m)"
+
+  if [[ -n "$failure_class" ]]; then
+    failure_class_json="\"$failure_class\""
+  fi
+
+  if command -v git >/dev/null 2>&1; then
+    source_revision="$(git rev-parse HEAD 2>/dev/null || printf unknown)"
+  fi
+
+  printf '{"attempt_id":"%s","captured_at":"%s","duration_seconds":%s,"failure_class":%s,"human_interventions":0,"node_version":null,"phase":"%s","pnpm_version":null,"result":"%s","retries":0,"runner":"%s","scenario":"%s","source_revision":"%s","status_code":%s,"task_class":"%s","task_id":"%s","vite_plus_version":null,"worktree_dirty":null}\n' \
+    "$AGENT_ATTEMPT_ID" "$captured_at" "$duration_seconds" "$failure_class_json" "$phase" \
+    "$result" "$runner" "$scenario" "$source_revision" "$status_code" "$AGENT_TASK_CLASS" "$AGENT_TASK_ID" \
+    > "$AGENT_ATTEMPT_ARTIFACT_DIR/$phase.json"
 }
 
 agent_vp() {
@@ -56,18 +92,20 @@ agent_run_logged() {
   fi
 
   set +e
-  "$@" 2>&1 | tee "$log_path"
-  local command_status=${PIPESTATUS[0]}
-
-  if ((restore_errexit == 1)); then
-    set -e
-  fi
+  (set -e; "$@") 2>&1 | tee "$log_path"
+  local pipeline_status=("${PIPESTATUS[@]}")
+  local command_status=${pipeline_status[0]}
+  local tee_status=${pipeline_status[1]}
 
   local duration_seconds=$((SECONDS - started_at))
   local result="success"
   local recorded_failure=""
 
-  if ((command_status != 0)); then
+  if ((tee_status != 0)); then
+    command_status="$tee_status"
+    result="failure"
+    recorded_failure="artifact/log_write_failed"
+  elif ((command_status != 0)); then
     result="failure"
     recorded_failure="$failure_class"
     if [[ "${AGENT_EXPECTED_FAILURE:-0}" == "1" ]]; then
@@ -75,8 +113,21 @@ agent_run_logged() {
     fi
   fi
 
+  set +e
   agent_record record "$phase" "$scenario" "$result" "$recorded_failure" \
     "$duration_seconds" "$command_status" "$log_path"
+  local record_status=$?
+
+  if ((restore_errexit == 1)); then
+    set -e
+  fi
+
+  if ((record_status != 0)); then
+    echo "Agent evidence recording failed with status $record_status." >&2
+    if ((command_status == 0)); then
+      return "$record_status"
+    fi
+  fi
 
   return "$command_status"
 }

--- a/scripts/agent-live-execute.sh
+++ b/scripts/agent-live-execute.sh
@@ -39,11 +39,11 @@ for target in "$@"; do
 done
 
 live_test() {
-  pnpm exec vp pack
+  agent_vp pack
   if [[ "${AGENT_LIVE_REFRESH_TOKENS:-0}" == "1" ]]; then
     node ./scripts/run-live-with-fresh-tokens.ts "$@"
   else
-    pnpm exec vp test run --config vitest.live.config.ts "$@"
+    agent_vp test run --config vitest.live.config.ts "$@"
   fi
 }
 

--- a/scripts/agent-live-execute.sh
+++ b/scripts/agent-live-execute.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(dirname "$0")/agent-common.sh"
+
+agent_require_context
+
+has_token_pair=0
+has_bootstrap_credentials=0
+
+if [[ -n "${PUTIO_TOKEN_FIRST_PARTY:-}" && -n "${PUTIO_TOKEN_THIRD_PARTY:-}" ]]; then
+  has_token_pair=1
+fi
+
+if [[ -n "${PUTIO_TEST_USERNAME:-}" && -n "${PUTIO_TEST_PASSWORD:-}" && -n "${PUTIO_CLIENT_ID_FIRST_PARTY:-}" && -n "${PUTIO_CLIENT_SECRET_FIRST_PARTY:-}" ]]; then
+  has_bootstrap_credentials=1
+fi
+
+if ((has_token_pair == 0 && has_bootstrap_credentials == 0)); then
+  echo "Runner secret injection must provide a live token pair or the first-party bootstrap credential set." >&2
+  exit 2
+fi
+
+if [[ "${AGENT_LIVE_REFRESH_TOKENS:-0}" == "1" && "$has_bootstrap_credentials" != "1" ]]; then
+  echo "AGENT_LIVE_REFRESH_TOKENS requires the first-party bootstrap credential set." >&2
+  exit 2
+fi
+
+if (($# == 0)); then
+  echo "Pass one or more explicit test/live/*.test.ts targets. The unattended path has no mutation-heavy default." >&2
+  exit 2
+fi
+
+for target in "$@"; do
+  if [[ ! "$target" =~ ^test/live/[A-Za-z0-9._-]+\.test\.ts$ ]] || [[ ! -f "$target" ]]; then
+    echo "Unsupported live target: $target" >&2
+    exit 2
+  fi
+done
+
+live_test() {
+  pnpm exec vp pack
+  if [[ "${AGENT_LIVE_REFRESH_TOKENS:-0}" == "1" ]]; then
+    node ./scripts/run-live-with-fresh-tokens.ts "$@"
+  else
+    pnpm exec vp test run --config vitest.live.config.ts "$@"
+  fi
+}
+
+set +e
+agent_run_logged live explicit-live-targets live/failed live_test "$@"
+live_status=$?
+set -e
+
+log_path="$AGENT_ATTEMPT_ARTIFACT_DIR/live.log"
+set +e
+node ./scripts/agent-record.ts scan "$log_path"
+scan_status=$?
+set -e
+
+if ((scan_status != 0)); then
+  agent_record record live explicit-live-targets failure artifact/secret_leak 0 1 "$log_path"
+  exit 1
+fi
+
+exit "$live_status"

--- a/scripts/agent-live-execute.sh
+++ b/scripts/agent-live-execute.sh
@@ -16,34 +16,45 @@ if [[ -n "${PUTIO_TEST_USERNAME:-}" && -n "${PUTIO_TEST_PASSWORD:-}" && -n "${PU
   has_bootstrap_credentials=1
 fi
 
-if ((has_token_pair == 0 && has_bootstrap_credentials == 0)); then
-  echo "Runner secret injection must provide a live token pair or the first-party bootstrap credential set." >&2
-  exit 2
-fi
-
-if [[ "${AGENT_LIVE_REFRESH_TOKENS:-0}" == "1" && "$has_bootstrap_credentials" != "1" ]]; then
-  echo "AGENT_LIVE_REFRESH_TOKENS requires the first-party bootstrap credential set." >&2
-  exit 2
-fi
-
-if (($# == 0)); then
-  echo "Pass one or more explicit test/live/*.test.ts targets. The unattended path has no mutation-heavy default." >&2
-  exit 2
-fi
-
-for target in "$@"; do
-  if [[ ! "$target" =~ ^test/live/[A-Za-z0-9._-]+\.test\.ts$ ]] || [[ ! -f "$target" ]]; then
-    echo "Unsupported live target: $target" >&2
-    exit 2
+validate_live_invocation() {
+  if ((has_token_pair == 0 && has_bootstrap_credentials == 0)); then
+    echo "Runner secret injection must provide a live token pair or the first-party bootstrap credential set." >&2
+    return 2
   fi
-done
+
+  if [[ "${AGENT_LIVE_REFRESH_TOKENS:-0}" == "1" && "$has_bootstrap_credentials" != "1" ]]; then
+    echo "AGENT_LIVE_REFRESH_TOKENS requires the first-party bootstrap credential set." >&2
+    return 2
+  fi
+
+  if (($# == 0)); then
+    echo "Pass one or more explicit test/live/*.test.ts targets. The unattended path has no mutation-heavy default." >&2
+    return 2
+  fi
+
+  for target in "$@"; do
+    if [[ ! "$target" =~ ^test/live/[A-Za-z0-9._-]+\.test\.ts$ ]] || [[ ! -f "$target" ]]; then
+      echo "Unsupported live target: $target" >&2
+      return 2
+    fi
+  done
+}
+
+set +e
+AGENT_EXPECTED_FAILURE=1 agent_run_logged live-input validate-live-invocation input/invalid validate_live_invocation "$@"
+input_status=$?
+set -e
+
+if ((input_status != 0)); then
+  exit "$input_status"
+fi
 
 live_test() {
   agent_vp pack
   if [[ "${AGENT_LIVE_REFRESH_TOKENS:-0}" == "1" ]]; then
     node ./scripts/run-live-with-fresh-tokens.ts "$@"
   else
-    agent_vp test run --config vitest.live.config.ts "$@"
+    node ./scripts/run-live-tests.ts "$@"
   fi
 }
 
@@ -52,15 +63,14 @@ agent_run_logged live explicit-live-targets live/failed live_test "$@"
 live_status=$?
 set -e
 
-log_path="$AGENT_ATTEMPT_ARTIFACT_DIR/live.log"
 set +e
-node ./scripts/agent-record.ts scan "$log_path"
+agent_run_logged live-scan scan-live-output artifact/secret_leak \
+  node ./scripts/agent-record.ts scan "$AGENT_ATTEMPT_ARTIFACT_DIR/live.log"
 scan_status=$?
 set -e
 
 if ((scan_status != 0)); then
-  agent_record record live explicit-live-targets failure artifact/secret_leak 0 1 "$log_path"
-  exit 1
+  exit "$scan_status"
 fi
 
 exit "$live_status"

--- a/scripts/agent-live-test.sh
+++ b/scripts/agent-live-test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(dirname "$0")/agent-common.sh"
+
+agent_require_context
+
+if [[ -n "${PUTIO_TOKEN_FIRST_PARTY:-}" && -n "${PUTIO_TOKEN_THIRD_PARTY:-}" ]] || \
+  [[ -n "${PUTIO_TEST_USERNAME:-}" && -n "${PUTIO_TEST_PASSWORD:-}" && -n "${PUTIO_CLIENT_ID_FIRST_PARTY:-}" && -n "${PUTIO_CLIENT_SECRET_FIRST_PARTY:-}" ]]; then
+  exec ./scripts/agent-live-execute.sh "$@"
+fi
+
+missing_identity() {
+  echo "Runner live identity is unavailable." >&2
+  echo "Inject a live token pair or bootstrap credentials directly, or inject INFISICAL_TOKEN plus this repo's Infisical project and path coordinates." >&2
+  return 2
+}
+
+if [[ -z "${INFISICAL_TOKEN:-}" || -z "${PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_ID:-}" || -z "${PUTIO_SDK_TYPESCRIPT_INFISICAL_PATH:-}" ]]; then
+  AGENT_EXPECTED_FAILURE=1 agent_run_logged live missing-runner-identity runner/missing_identity missing_identity
+  exit 2
+fi
+
+if ! command -v infisical >/dev/null 2>&1; then
+  AGENT_EXPECTED_FAILURE=1 agent_run_logged live missing-infisical-cli runner/missing_tool missing_identity
+  exit 2
+fi
+
+exec infisical run \
+  --silent \
+  --domain "${PUTIO_INFISICAL_DOMAIN:-https://eu.infisical.com/api}" \
+  --projectId "$PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_ID" \
+  --env "${PUTIO_SDK_TYPESCRIPT_INFISICAL_ENV:-dev}" \
+  --path "$PUTIO_SDK_TYPESCRIPT_INFISICAL_PATH" \
+  -- ./scripts/agent-live-execute.sh "$@"

--- a/scripts/agent-live-test.sh
+++ b/scripts/agent-live-test.sh
@@ -16,20 +16,39 @@ missing_identity() {
   return 2
 }
 
+missing_infisical_cli() {
+  echo "The Infisical CLI is unavailable on this runner." >&2
+  echo "Install the runner-managed CLI or inject the live token pair or bootstrap credentials directly." >&2
+  return 2
+}
+
 if [[ -z "${INFISICAL_TOKEN:-}" || -z "${PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_ID:-}" || -z "${PUTIO_SDK_TYPESCRIPT_INFISICAL_PATH:-}" ]]; then
   AGENT_EXPECTED_FAILURE=1 agent_run_logged live missing-runner-identity runner/missing_identity missing_identity
   exit 2
 fi
 
 if ! command -v infisical >/dev/null 2>&1; then
-  AGENT_EXPECTED_FAILURE=1 agent_run_logged live missing-infisical-cli runner/missing_tool missing_identity
+  AGENT_EXPECTED_FAILURE=1 agent_run_logged live missing-infisical-cli runner/missing_tool missing_infisical_cli
   exit 2
 fi
 
-exec infisical run \
-  --silent \
-  --domain "${PUTIO_INFISICAL_DOMAIN:-https://eu.infisical.com/api}" \
-  --projectId "$PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_ID" \
-  --env "${PUTIO_SDK_TYPESCRIPT_INFISICAL_ENV:-dev}" \
-  --path "$PUTIO_SDK_TYPESCRIPT_INFISICAL_PATH" \
-  -- ./scripts/agent-live-execute.sh "$@"
+run_infisical() {
+  node ./scripts/run-infisical.ts "$@"
+}
+
+set +e
+agent_run_logged live-injection infisical-injection runner/secret_injection_failed run_infisical "$@"
+injection_status=$?
+set -e
+
+set +e
+agent_run_logged live-injection-scan scan-infisical-output artifact/secret_leak \
+  node ./scripts/agent-record.ts scan "$AGENT_ATTEMPT_ARTIFACT_DIR/live-injection.log"
+scan_status=$?
+set -e
+
+if ((scan_status != 0)); then
+  exit "$scan_status"
+fi
+
+exit "$injection_status"

--- a/scripts/agent-record.ts
+++ b/scripts/agent-record.ts
@@ -2,21 +2,9 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 
+import { collectSecretValues } from "./agent-secret-values.ts";
+
 const identifierPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
-const secretKeys = [
-  "INFISICAL_TOKEN",
-  "PUTIO_CLIENT_SECRET_FIRST_PARTY",
-  "PUTIO_TEST_PASSWORD",
-  "PUTIO_TEST_SECONDARY_PASSWORD",
-  "PUTIO_TEST_TOTP",
-  "PUTIO_TEST_TOTP_REFERENCE",
-  "PUTIO_TEST_SECONDARY_TOTP",
-  "PUTIO_TEST_SECONDARY_TOTP_REFERENCE",
-  "PUTIO_TOKEN_FIRST_PARTY",
-  "PUTIO_TOKEN_PAYMENT_OWNER",
-  "PUTIO_TOKEN_PAYMENT_SUB_ACCOUNT",
-  "PUTIO_TOKEN_THIRD_PARTY",
-];
 
 const requireArgument = (value: string | undefined, name: string): string => {
   if (!value) {
@@ -42,19 +30,15 @@ const commandOutput = (command: string, args: readonly string[]): string =>
 const optionalCommandOutput = (command: string, args: readonly string[]): string | null => {
   try {
     return commandOutput(command, args);
-  } catch (error) {
-    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-      return null;
-    }
-
-    throw error;
+  } catch {
+    return null;
   }
 };
 
 const vitePlusVersion = (): string | null => {
   const localVitePlus = resolve("node_modules/.bin/vp");
   const output = existsSync(localVitePlus)
-    ? commandOutput(localVitePlus, ["--version"])
+    ? optionalCommandOutput(localVitePlus, ["--version"])
     : optionalCommandOutput("vp", ["--version"]);
 
   return output?.split("\n", 1)[0] ?? null;
@@ -130,9 +114,8 @@ const scan = (paths: readonly string[]): void => {
   for (const path of paths) {
     let contents = readFileSync(path, "utf8");
 
-    for (const key of secretKeys) {
-      const value = process.env[key];
-      if (value && value.length >= 8 && contents.includes(value)) {
+    for (const [key, value] of collectSecretValues()) {
+      if (contents.includes(value)) {
         leaks.push(`${path}:${key}`);
         contents = contents.replaceAll(value, `[REDACTED:${key}]`);
       }

--- a/scripts/agent-record.ts
+++ b/scripts/agent-record.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 
 const identifierPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
@@ -38,6 +38,27 @@ const requireIdentifier = (value: string | undefined, name: string): string => {
 
 const commandOutput = (command: string, args: readonly string[]): string =>
   execFileSync(command, args, { encoding: "utf8" }).trim();
+
+const optionalCommandOutput = (command: string, args: readonly string[]): string | null => {
+  try {
+    return commandOutput(command, args);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+};
+
+const vitePlusVersion = (): string | null => {
+  const localVitePlus = resolve("node_modules/.bin/vp");
+  const output = existsSync(localVitePlus)
+    ? commandOutput(localVitePlus, ["--version"])
+    : optionalCommandOutput("vp", ["--version"]);
+
+  return output?.split("\n", 1)[0] ?? null;
+};
 
 const getArtifactDirectory = (): string => {
   const taskId = requireIdentifier(process.env.AGENT_TASK_ID, "AGENT_TASK_ID");
@@ -79,7 +100,7 @@ const record = (args: readonly string[]): void => {
     human_interventions: 0,
     node_version: process.version,
     phase,
-    pnpm_version: commandOutput("pnpm", ["--version"]),
+    pnpm_version: optionalCommandOutput("pnpm", ["--version"]),
     result,
     retries: 0,
     runner: `${process.platform}-${process.arch}`,
@@ -88,6 +109,7 @@ const record = (args: readonly string[]): void => {
     status_code: statusCode,
     task_class: process.env.AGENT_TASK_CLASS ?? "implementation",
     task_id: requireIdentifier(process.env.AGENT_TASK_ID, "AGENT_TASK_ID"),
+    vite_plus_version: vitePlusVersion(),
     worktree_dirty: commandOutput("git", ["status", "--porcelain"]).length > 0,
   };
 

--- a/scripts/agent-record.ts
+++ b/scripts/agent-record.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+const identifierPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const secretKeys = [
+  "INFISICAL_TOKEN",
+  "PUTIO_CLIENT_SECRET_FIRST_PARTY",
+  "PUTIO_TEST_PASSWORD",
+  "PUTIO_TEST_SECONDARY_PASSWORD",
+  "PUTIO_TEST_TOTP",
+  "PUTIO_TEST_TOTP_REFERENCE",
+  "PUTIO_TEST_SECONDARY_TOTP",
+  "PUTIO_TEST_SECONDARY_TOTP_REFERENCE",
+  "PUTIO_TOKEN_FIRST_PARTY",
+  "PUTIO_TOKEN_PAYMENT_OWNER",
+  "PUTIO_TOKEN_PAYMENT_SUB_ACCOUNT",
+  "PUTIO_TOKEN_THIRD_PARTY",
+];
+
+const requireArgument = (value: string | undefined, name: string): string => {
+  if (!value) {
+    throw new Error(`Missing ${name}`);
+  }
+
+  return value;
+};
+
+const requireIdentifier = (value: string | undefined, name: string): string => {
+  const identifier = requireArgument(value, name);
+
+  if (!identifierPattern.test(identifier)) {
+    throw new Error(`${name} contains unsupported characters`);
+  }
+
+  return identifier;
+};
+
+const commandOutput = (command: string, args: readonly string[]): string =>
+  execFileSync(command, args, { encoding: "utf8" }).trim();
+
+const getArtifactDirectory = (): string => {
+  const taskId = requireIdentifier(process.env.AGENT_TASK_ID, "AGENT_TASK_ID");
+  const attemptId = requireIdentifier(process.env.AGENT_ATTEMPT_ID, "AGENT_ATTEMPT_ID");
+  const artifactsRoot = process.env.AGENT_ARTIFACTS_DIR ?? ".artifacts/agent-readiness";
+
+  return resolve(artifactsRoot, taskId, attemptId);
+};
+
+const record = (args: readonly string[]): void => {
+  const [rawPhase, scenario, result, failureClass, rawDuration, rawStatus, rawLogPath] = args;
+  const phase = requireIdentifier(rawPhase, "phase");
+  const durationSeconds = Number(requireArgument(rawDuration, "duration_seconds"));
+  const statusCode = Number(requireArgument(rawStatus, "status_code"));
+  const logPath = requireArgument(rawLogPath, "log_path");
+
+  if (!Number.isInteger(durationSeconds) || durationSeconds < 0) {
+    throw new Error("duration_seconds must be a non-negative integer");
+  }
+
+  if (!Number.isInteger(statusCode) || statusCode < 0) {
+    throw new Error("status_code must be a non-negative integer");
+  }
+
+  if (result !== "success" && result !== "failure" && result !== "expected_failure") {
+    throw new Error("result must be success, failure, or expected_failure");
+  }
+
+  const artifactDirectory = getArtifactDirectory();
+  mkdirSync(artifactDirectory, { recursive: true });
+
+  const payload = {
+    artifact_path: relative(process.cwd(), artifactDirectory),
+    attempt_id: requireIdentifier(process.env.AGENT_ATTEMPT_ID, "AGENT_ATTEMPT_ID"),
+    captured_at: new Date().toISOString(),
+    duration_seconds: durationSeconds,
+    evidence_log: relative(process.cwd(), resolve(logPath)),
+    failure_class: failureClass || null,
+    human_interventions: 0,
+    node_version: process.version,
+    phase,
+    pnpm_version: commandOutput("pnpm", ["--version"]),
+    result,
+    retries: 0,
+    runner: `${process.platform}-${process.arch}`,
+    scenario: requireArgument(scenario, "scenario"),
+    source_revision: commandOutput("git", ["rev-parse", "HEAD"]),
+    status_code: statusCode,
+    task_class: process.env.AGENT_TASK_CLASS ?? "implementation",
+    task_id: requireIdentifier(process.env.AGENT_TASK_ID, "AGENT_TASK_ID"),
+    worktree_dirty: commandOutput("git", ["status", "--porcelain"]).length > 0,
+  };
+
+  writeFileSync(
+    resolve(artifactDirectory, `${phase}.json`),
+    `${JSON.stringify(payload, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+};
+
+const scan = (paths: readonly string[]): void => {
+  if (paths.length === 0) {
+    throw new Error("scan requires at least one artifact path");
+  }
+
+  const leaks: string[] = [];
+
+  for (const path of paths) {
+    let contents = readFileSync(path, "utf8");
+
+    for (const key of secretKeys) {
+      const value = process.env[key];
+      if (value && value.length >= 8 && contents.includes(value)) {
+        leaks.push(`${path}:${key}`);
+        contents = contents.replaceAll(value, `[REDACTED:${key}]`);
+      }
+    }
+
+    writeFileSync(path, contents, { mode: 0o600 });
+  }
+
+  if (leaks.length > 0) {
+    throw new Error(`Redacted injected secrets from artifact logs: ${leaks.join(", ")}`);
+  }
+};
+
+const [command, ...args] = process.argv.slice(2);
+
+if (command === "record") {
+  record(args);
+} else if (command === "scan") {
+  scan(args);
+} else {
+  throw new Error("Expected record or scan command");
+}

--- a/scripts/agent-run.sh
+++ b/scripts/agent-run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+finish() {
+  local run_status=$?
+  local teardown_status=0
+  trap - EXIT
+
+  set +e
+  AGENT_RUN_STATUS="$run_status" ./scripts/agent-teardown.sh
+  teardown_status=$?
+  set -e
+
+  if ((run_status != 0)); then
+    exit "$run_status"
+  fi
+
+  exit "$teardown_status"
+}
+
+trap finish EXIT
+./scripts/agent-bootstrap.sh
+./scripts/agent-verify.sh

--- a/scripts/agent-run.sh
+++ b/scripts/agent-run.sh
@@ -12,6 +12,10 @@ finish() {
   teardown_status=$?
   set -e
 
+  if ((teardown_status != 0)); then
+    echo "Agent teardown failed with status $teardown_status." >&2
+  fi
+
   if ((run_status != 0)); then
     exit "$run_status"
   fi

--- a/scripts/agent-secret-values.spec.ts
+++ b/scripts/agent-secret-values.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { redactSecretValues } from "./agent-secret-values.ts";
+
+describe("redactSecretValues", () => {
+  it("redacts short and secondary fixture secrets", () => {
+    const result = redactSecretValues("totp=123456 owner=owner-token secondary=secondary-pass", {
+      PUTIO_TEST_SECONDARY_PASSWORD: "secondary-pass",
+      PUTIO_TEST_TOTP: "123456",
+      PUTIO_TOKEN_PAYMENT_OWNER: "owner-token",
+    });
+
+    expect(result.output).toBe(
+      "totp=[REDACTED:PUTIO_TEST_TOTP] owner=[REDACTED:PUTIO_TOKEN_PAYMENT_OWNER] secondary=[REDACTED:PUTIO_TEST_SECONDARY_PASSWORD]",
+    );
+    expect(result.leakedKeys).toEqual([
+      "PUTIO_TEST_SECONDARY_PASSWORD",
+      "PUTIO_TEST_TOTP",
+      "PUTIO_TOKEN_PAYMENT_OWNER",
+    ]);
+  });
+
+  it("does not treat empty values as secrets", () => {
+    expect(redactSecretValues("ordinary output", { PUTIO_TEST_TOTP: "" })).toEqual({
+      leakedKeys: [],
+      output: "ordinary output",
+    });
+  });
+});

--- a/scripts/agent-secret-values.ts
+++ b/scripts/agent-secret-values.ts
@@ -1,0 +1,44 @@
+export const secretEnvironmentKeys = [
+  "INFISICAL_TOKEN",
+  "PUTIO_CLIENT_SECRET_FIRST_PARTY",
+  "PUTIO_TEST_PASSWORD",
+  "PUTIO_TEST_SECONDARY_PASSWORD",
+  "PUTIO_TEST_TOTP",
+  "PUTIO_TEST_TOTP_REFERENCE",
+  "PUTIO_TEST_SECONDARY_TOTP",
+  "PUTIO_TEST_SECONDARY_TOTP_REFERENCE",
+  "PUTIO_TOKEN_FIRST_PARTY",
+  "PUTIO_TOKEN_PAYMENT_OWNER",
+  "PUTIO_TOKEN_PAYMENT_SUB_ACCOUNT",
+  "PUTIO_TOKEN_THIRD_PARTY",
+] as const;
+
+export type SecretEnvironmentKey = (typeof secretEnvironmentKeys)[number];
+
+export const collectSecretValues = (
+  overrides: Partial<Record<SecretEnvironmentKey, string | undefined>> = {},
+): ReadonlyArray<readonly [SecretEnvironmentKey, string]> =>
+  secretEnvironmentKeys.flatMap((key) => {
+    const value = overrides[key] ?? process.env[key];
+    return typeof value === "string" && value.length > 0 ? [[key, value]] : [];
+  });
+
+export const redactSecretValues = (
+  output: string,
+  overrides: Partial<Record<SecretEnvironmentKey, string | undefined>> = {},
+): { readonly leakedKeys: readonly SecretEnvironmentKey[]; readonly output: string } => {
+  let redacted = output;
+  const leakedKeys: SecretEnvironmentKey[] = [];
+
+  for (const [key, value] of collectSecretValues(overrides)) {
+    if (redacted.includes(value)) {
+      redacted = redacted.replaceAll(value, `[REDACTED:${key}]`);
+      leakedKeys.push(key);
+    }
+  }
+
+  return {
+    leakedKeys,
+    output: redacted,
+  };
+};

--- a/scripts/agent-teardown.sh
+++ b/scripts/agent-teardown.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(dirname "$0")/agent-common.sh"
+
+agent_require_context
+
+run_status="${AGENT_RUN_STATUS:-0}"
+result="success"
+failure_class=""
+
+if [[ ! "$run_status" =~ ^[0-9]+$ ]]; then
+  echo "AGENT_RUN_STATUS must be a non-negative integer." >&2
+  exit 2
+fi
+
+if ((run_status != 0)); then
+  result="failure"
+  failure_class="lifecycle/failed"
+fi
+
+log_path="$AGENT_ATTEMPT_ARTIFACT_DIR/teardown.log"
+printf 'teardown complete\n' > "$log_path"
+agent_record record teardown lifecycle "$result" "$failure_class" 0 "$run_status" "$log_path"

--- a/scripts/agent-verify.sh
+++ b/scripts/agent-verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(dirname "$0")/agent-common.sh"
+
+agent_require_context
+
+verify() {
+  pnpm exec vp run verify
+  pnpm exec vp run lint:package
+}
+
+agent_run_logged verify canonical-gate verification/failed verify

--- a/scripts/agent-verify.sh
+++ b/scripts/agent-verify.sh
@@ -6,8 +6,8 @@ source "$(dirname "$0")/agent-common.sh"
 agent_require_context
 
 verify() {
-  pnpm exec vp run verify
-  pnpm exec vp run lint:package
+  agent_vp run verify
+  agent_vp run lint:package
 }
 
 agent_run_logged verify canonical-gate verification/failed verify

--- a/scripts/live-test-process.ts
+++ b/scripts/live-test-process.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { redactSecretValues, type SecretEnvironmentKey } from "./agent-secret-values.ts";
+
+export type LiveTestProcessResult = {
+  readonly error: Error | null;
+  readonly leakedKeys: readonly SecretEnvironmentKey[];
+  readonly status: number;
+};
+
+export const runLiveTestProcess = (
+  targets: readonly string[],
+  environment: NodeJS.ProcessEnv,
+  secretOverrides: Partial<Record<SecretEnvironmentKey, string | undefined>> = {},
+): LiveTestProcessResult => {
+  const localVitePlus = resolve("node_modules/.bin/vp");
+  const vitePlusCommand = existsSync(localVitePlus) ? localVitePlus : "vp";
+  const result = spawnSync(
+    vitePlusCommand,
+    ["test", "run", "--config", "vitest.live.config.ts", ...targets],
+    {
+      encoding: "utf8",
+      env: environment,
+      maxBuffer: 20 * 1024 * 1024,
+    },
+  );
+  const leakedKeys = new Set<SecretEnvironmentKey>();
+
+  const redact = (output: string): string => {
+    const redacted = redactSecretValues(output, secretOverrides);
+
+    for (const key of redacted.leakedKeys) {
+      leakedKeys.add(key);
+    }
+
+    return redacted.output;
+  };
+
+  process.stdout.write(redact(result.stdout ?? ""));
+  process.stderr.write(redact(result.stderr ?? ""));
+
+  return {
+    error:
+      result.error instanceof Error
+        ? result.error
+        : result.error
+          ? new Error("Unknown live test process failure")
+          : null,
+    leakedKeys: [...leakedKeys],
+    status: result.status ?? 1,
+  };
+};

--- a/scripts/run-infisical.ts
+++ b/scripts/run-infisical.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from "node:child_process";
+
+import { redactSecretValues } from "./agent-secret-values.ts";
+
+const targets = process.argv.slice(2);
+const projectId = process.env.PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_ID;
+const secretPath = process.env.PUTIO_SDK_TYPESCRIPT_INFISICAL_PATH;
+
+if (!projectId || !secretPath) {
+  throw new Error("Expected Infisical project and path coordinates");
+}
+
+const result = spawnSync(
+  "infisical",
+  [
+    "run",
+    "--silent",
+    "--domain",
+    process.env.PUTIO_INFISICAL_DOMAIN ?? "https://eu.infisical.com/api",
+    "--projectId",
+    projectId,
+    "--env",
+    process.env.PUTIO_SDK_TYPESCRIPT_INFISICAL_ENV ?? "dev",
+    "--path",
+    secretPath,
+    "--",
+    "./scripts/agent-live-execute.sh",
+    ...targets,
+  ],
+  {
+    encoding: "utf8",
+    env: process.env,
+    maxBuffer: 20 * 1024 * 1024,
+  },
+);
+const stdout = redactSecretValues(result.stdout ?? "");
+const stderr = redactSecretValues(result.stderr ?? "");
+const leakedKeys = [...new Set([...stdout.leakedKeys, ...stderr.leakedKeys])];
+
+process.stdout.write(stdout.output);
+process.stderr.write(stderr.output);
+
+if (leakedKeys.length > 0) {
+  console.error(`Infisical output attempted to expose injected secrets: ${leakedKeys.join(", ")}`);
+  process.exit(1);
+}
+
+if (result.error) {
+  console.error(`Infisical failed to start or capture output: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/run-live-tests.ts
+++ b/scripts/run-live-tests.ts
@@ -1,0 +1,23 @@
+import { runLiveTestProcess } from "./live-test-process.ts";
+
+const targets = process.argv.slice(2);
+
+if (targets.length === 0) {
+  throw new Error("Expected at least one live test target");
+}
+
+const result = runLiveTestProcess(targets, process.env);
+
+if (result.leakedKeys.length > 0) {
+  console.error(
+    `Live test output attempted to expose injected secrets: ${result.leakedKeys.join(", ")}`,
+  );
+  process.exit(1);
+}
+
+if (result.error) {
+  console.error(`Live test process failed to start or capture output: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status);

--- a/scripts/run-live-with-fresh-tokens.ts
+++ b/scripts/run-live-with-fresh-tokens.ts
@@ -1,10 +1,7 @@
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
-
 import { createPutioSdkPromiseClient } from "../dist/index.js";
 import { bootstrapRuntimeTokens } from "../test/live/support/bootstrap.ts";
 import { readBootstrapSecrets } from "../test/live/support/secrets.ts";
+import { runLiveTestProcess } from "./live-test-process.ts";
 
 const targets = process.argv.slice(2);
 
@@ -16,80 +13,47 @@ const bootstrapped = await bootstrapRuntimeTokens(readBootstrapSecrets(), async 
   createPutioSdkPromiseClient(config),
 );
 
-const localVitePlus = resolve("node_modules/.bin/vp");
-const vitePlusCommand = existsSync(localVitePlus) ? localVitePlus : "vp";
-
-const result = spawnSync(
-  vitePlusCommand,
-  ["test", "run", "--config", "vitest.live.config.ts", ...targets],
-  {
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      PUTIO_TOKEN_FIRST_PARTY: bootstrapped.firstParty.accessToken,
-      PUTIO_TOKEN_THIRD_PARTY: bootstrapped.thirdParty.accessToken,
-    },
-    maxBuffer: 20 * 1024 * 1024,
-  },
-);
-
-if (result.error) {
-  throw result.error;
-}
+const liveEnvironment = {
+  ...process.env,
+  PUTIO_TOKEN_FIRST_PARTY: bootstrapped.firstParty.accessToken,
+  PUTIO_TOKEN_THIRD_PARTY: bootstrapped.thirdParty.accessToken,
+};
+const result = runLiveTestProcess(targets, liveEnvironment, {
+  PUTIO_TOKEN_FIRST_PARTY: bootstrapped.firstParty.accessToken,
+  PUTIO_TOKEN_THIRD_PARTY: bootstrapped.thirdParty.accessToken,
+});
 
 let cleanupError: Error | null = null;
+const cleanupClient = createPutioSdkPromiseClient({
+  accessToken: bootstrapped.firstParty.accessToken,
+});
 
 try {
   if (bootstrapped.firstParty.tokenId === null) {
     throw new Error("Ephemeral first-party token did not return a token ID for cleanup");
   }
 
-  const cleanupClient = createPutioSdkPromiseClient({
-    accessToken: bootstrapped.firstParty.accessToken,
-  });
   await cleanupClient.auth.revokeClient(bootstrapped.firstParty.tokenId);
-  await cleanupClient.dispose();
 } catch (error) {
   cleanupError = error instanceof Error ? error : new Error("Unknown token cleanup failure");
+} finally {
+  try {
+    await cleanupClient.dispose();
+  } catch (error) {
+    cleanupError ??=
+      error instanceof Error ? error : new Error("Unknown cleanup client disposal failure");
+  }
 }
 
-const secretValues = [
-  ["PUTIO_TOKEN_FIRST_PARTY", bootstrapped.firstParty.accessToken],
-  ["PUTIO_TOKEN_THIRD_PARTY", bootstrapped.thirdParty.accessToken],
-  ["PUTIO_CLIENT_SECRET_FIRST_PARTY", process.env.PUTIO_CLIENT_SECRET_FIRST_PARTY],
-  ["PUTIO_TEST_PASSWORD", process.env.PUTIO_TEST_PASSWORD],
-  ["PUTIO_TEST_TOTP", process.env.PUTIO_TEST_TOTP],
-  ["PUTIO_TEST_TOTP_REFERENCE", process.env.PUTIO_TEST_TOTP_REFERENCE],
-].filter(
-  (entry): entry is [string, string] => typeof entry[1] === "string" && entry[1].length >= 8,
-);
+if (result.leakedKeys.length > 0) {
+  console.error(
+    `Live test output attempted to expose injected secrets: ${result.leakedKeys.join(", ")}`,
+  );
+  process.exit(1);
+}
 
-const redact = (output: string): { readonly output: string; readonly redactedKeys: string[] } => {
-  let redacted = output;
-  const redactedKeys: string[] = [];
-
-  for (const [key, value] of secretValues) {
-    if (redacted.includes(value)) {
-      redacted = redacted.replaceAll(value, `[REDACTED:${key}]`);
-      redactedKeys.push(key);
-    }
-  }
-
-  return {
-    output: redacted,
-    redactedKeys,
-  };
-};
-
-const stdout = redact(result.stdout ?? "");
-const stderr = redact(result.stderr ?? "");
-process.stdout.write(stdout.output);
-process.stderr.write(stderr.output);
-
-const leakedKeys = [...new Set([...stdout.redactedKeys, ...stderr.redactedKeys])];
-
-if (leakedKeys.length > 0) {
-  console.error(`Live test output attempted to expose injected secrets: ${leakedKeys.join(", ")}`);
+if (result.error) {
+  console.error(`Live test process failed to start or capture output: ${result.error.message}`);
   process.exit(1);
 }
 
@@ -98,4 +62,4 @@ if (cleanupError) {
   process.exit(1);
 }
 
-process.exit(result.status ?? 1);
+process.exit(result.status);

--- a/scripts/run-live-with-fresh-tokens.ts
+++ b/scripts/run-live-with-fresh-tokens.ts
@@ -1,0 +1,96 @@
+import { spawnSync } from "node:child_process";
+
+import { createPutioSdkPromiseClient } from "../dist/index.js";
+import { bootstrapRuntimeTokens } from "../test/live/support/bootstrap.ts";
+import { readBootstrapSecrets } from "../test/live/support/secrets.ts";
+
+const targets = process.argv.slice(2);
+
+if (targets.length === 0) {
+  throw new Error("Expected at least one live test target");
+}
+
+const bootstrapped = await bootstrapRuntimeTokens(readBootstrapSecrets(), async (config = {}) =>
+  createPutioSdkPromiseClient(config),
+);
+
+const result = spawnSync(
+  "pnpm",
+  ["exec", "vp", "test", "run", "--config", "vitest.live.config.ts", ...targets],
+  {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PUTIO_TOKEN_FIRST_PARTY: bootstrapped.firstParty.accessToken,
+      PUTIO_TOKEN_THIRD_PARTY: bootstrapped.thirdParty.accessToken,
+    },
+    maxBuffer: 20 * 1024 * 1024,
+  },
+);
+
+if (result.error) {
+  throw result.error;
+}
+
+let cleanupError: Error | null = null;
+
+try {
+  if (bootstrapped.firstParty.tokenId === null) {
+    throw new Error("Ephemeral first-party token did not return a token ID for cleanup");
+  }
+
+  const cleanupClient = createPutioSdkPromiseClient({
+    accessToken: bootstrapped.firstParty.accessToken,
+  });
+  await cleanupClient.auth.revokeClient(bootstrapped.firstParty.tokenId);
+  await cleanupClient.dispose();
+} catch (error) {
+  cleanupError = error instanceof Error ? error : new Error("Unknown token cleanup failure");
+}
+
+const secretValues = [
+  ["PUTIO_TOKEN_FIRST_PARTY", bootstrapped.firstParty.accessToken],
+  ["PUTIO_TOKEN_THIRD_PARTY", bootstrapped.thirdParty.accessToken],
+  ["PUTIO_CLIENT_SECRET_FIRST_PARTY", process.env.PUTIO_CLIENT_SECRET_FIRST_PARTY],
+  ["PUTIO_TEST_PASSWORD", process.env.PUTIO_TEST_PASSWORD],
+  ["PUTIO_TEST_TOTP", process.env.PUTIO_TEST_TOTP],
+  ["PUTIO_TEST_TOTP_REFERENCE", process.env.PUTIO_TEST_TOTP_REFERENCE],
+].filter(
+  (entry): entry is [string, string] => typeof entry[1] === "string" && entry[1].length >= 8,
+);
+
+const redact = (output: string): { readonly output: string; readonly redactedKeys: string[] } => {
+  let redacted = output;
+  const redactedKeys: string[] = [];
+
+  for (const [key, value] of secretValues) {
+    if (redacted.includes(value)) {
+      redacted = redacted.replaceAll(value, `[REDACTED:${key}]`);
+      redactedKeys.push(key);
+    }
+  }
+
+  return {
+    output: redacted,
+    redactedKeys,
+  };
+};
+
+const stdout = redact(result.stdout ?? "");
+const stderr = redact(result.stderr ?? "");
+process.stdout.write(stdout.output);
+process.stderr.write(stderr.output);
+
+const leakedKeys = [...new Set([...stdout.redactedKeys, ...stderr.redactedKeys])];
+
+if (leakedKeys.length > 0) {
+  console.error(`Live test output attempted to expose injected secrets: ${leakedKeys.join(", ")}`);
+  process.exit(1);
+}
+
+if (cleanupError) {
+  console.error(`Failed to revoke the ephemeral first-party token: ${cleanupError.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/run-live-with-fresh-tokens.ts
+++ b/scripts/run-live-with-fresh-tokens.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 
 import { createPutioSdkPromiseClient } from "../dist/index.js";
 import { bootstrapRuntimeTokens } from "../test/live/support/bootstrap.ts";
@@ -14,9 +16,12 @@ const bootstrapped = await bootstrapRuntimeTokens(readBootstrapSecrets(), async 
   createPutioSdkPromiseClient(config),
 );
 
+const localVitePlus = resolve("node_modules/.bin/vp");
+const vitePlusCommand = existsSync(localVitePlus) ? localVitePlus : "vp";
+
 const result = spawnSync(
-  "pnpm",
-  ["exec", "vp", "test", "run", "--config", "vitest.live.config.ts", ...targets],
+  vitePlusCommand,
+  ["test", "run", "--config", "vitest.live.config.ts", ...targets],
   {
     encoding: "utf8",
     env: {


### PR DESCRIPTION
## Summary

Adds one unattended lifecycle for repository and package verification, plus a secret-safe runner for explicit live-test targets. CI now executes the same lifecycle and retains machine-readable evidence.

Part of #108.

## Changed

- validates task identity, pinned Node/pnpm versions, frozen dependency setup, canonical verification, and teardown
- records per-phase JSON and logs under `.artifacts/agent-readiness/<task>/<attempt>/` with `0600` permissions
- uploads the evidence bundle from CI even when verification fails
- supports direct runner secrets or an injected Infisical machine identity for explicit `test/live/*.test.ts` targets
- supports fresh ephemeral runtime tokens and revokes the first-party token after success or failure
- stops copying ignored env files into managed worktrees and documents runner-owned secret injection

## Review aids

```mermaid
flowchart LR
  B["Bootstrap: identity, versions, frozen install"] --> V["Verify: repo and package gates"]
  V --> T["Teardown: terminal evidence"]
  B -->|failure| T
  V -->|failure| T
  I["Runner-injected secrets or machine identity"] --> L["Explicit safe live targets"]
  L --> R["Redacted evidence and token revocation"]
```

The lifecycle evidence records source revision, task/attempt identity, runner, duration, result, failure class, retry count, human interventions, and worktree cleanliness. Missing live identity is an inspectable expected failure (`runner/missing_identity`, status 2).

## Risks

- The full mutation-heavy live suite remains outside unattended defaults because it shares account state and quotas.
- Machine-identity creation and runner injection are intentionally environment-owned; this repository only consumes the injected identity.
- No public SDK contract changes.

## Verification

- committed-head lifecycle: 23 files / 133 tests, coverage gates, both Knip graphs, route matrix, publint, and ATTW passed
- package compatibility: strict Node consumer, Chromium, Firefox, WebKit, and Bun passed
- committed-head live checks: account and tunnel, 2 files / 9 tests passed with fresh token cleanup
- failure proof: missing Node, missing identity/tool, invalid input, provider output, `tee`, phase, and record-write failures all produced classified evidence
- evidence records reference `0d31957` with a clean worktree and `0600` files

## Complexity

One explicit bootstrap → verify → teardown path is shared by local agents and CI. Live verification is separate so deterministic package checks never acquire credentials or select stateful tests implicitly.
