### PR TITLE
test(live): add fresh-token runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Live SDK verification env file.
 # Copy this to `.env` or `.env.local` and fill only the values needed by the live targets you run.
 
+# Optional Infisical coordinates for `pnpm secrets:setup` or `infisical run`.
+# Keep INFISICAL_TOKEN in the runner environment rather than this file.
+PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_ID=""
+PUTIO_SDK_TYPESCRIPT_INFISICAL_PATH=""
+PUTIO_SDK_TYPESCRIPT_INFISICAL_ENV="dev"
+PUTIO_INFISICAL_DOMAIN="https://eu.infisical.com/api"
+
 # Bootstrap creds — used by `bootstrap:tokens` and credential live tests to mint fresh tokens.
 PUTIO_TEST_USERNAME=""
 PUTIO_TEST_PASSWORD=""

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -183,6 +183,29 @@ Single target:
 vp pack && vp test run --config vitest.live.config.ts test/live/auth.test.ts
 ```
 
+Run explicit targets with fresh runtime tokens:
+
+```bash
+pnpm test:live:fresh -- test/live/account.test.ts test/live/tunnel.test.ts
+```
+
+`test:live:fresh` uses the existing credential fixture to mint runtime tokens,
+runs only the named test files, and revokes the fresh first-party session before
+exiting, including when a test fails. It never writes the runtime tokens to an
+env file.
+
+An unattended runner can inject a scoped `INFISICAL_TOKEN` machine-identity
+access token and run the same command without materializing secrets:
+
+```bash
+infisical run --silent \
+  --domain "$PUTIO_INFISICAL_DOMAIN" \
+  --projectId "$PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_ID" \
+  --env "$PUTIO_SDK_TYPESCRIPT_INFISICAL_ENV" \
+  --path "$PUTIO_SDK_TYPESCRIPT_INFISICAL_PATH" \
+  -- pnpm test:live:fresh -- test/live/account.test.ts test/live/tunnel.test.ts
+```
+
 Run `pnpm secrets:setup` once per worktree to materialize `.env.local` from the
 Infisical `/sdk-typescript` path. The materialized file is `0600` and
 gitignored. Live commands auto-load `.env.local` first and then `.env`;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:compat:bun": "node ./scripts/test-compat-bun.ts",
     "test:compat:node": "node ./scripts/test-compat-node.ts",
     "test:live": "vp pack && vp test run --config vitest.live.config.ts",
+    "test:live:fresh": "vp pack && node ./scripts/test-live-fresh.ts",
     "validate:routes": "vp pack && vp run validate:routes:packed",
     "validate:routes:packed": "node ./scripts/validate-route-matrix.ts",
     "verify": "vp check . && vp pack && knip && knip --production --no-gitignore && vp run validate:routes:packed && vp test run --coverage --passWithNoTests"

--- a/scripts/test-live-fresh.ts
+++ b/scripts/test-live-fresh.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
 
 import {
   bootstrapFirstPartyToken,
@@ -11,25 +12,39 @@ const args = process.argv.slice(2);
 const targets = args[0] === "--" ? args.slice(1) : args;
 
 if (targets.length === 0) {
-  throw new Error("Pass one or more explicit test/live/*.test.ts files");
+  throw new Error("Pass one or more explicit test/live/**/*.test.ts files");
 }
 
+const liveRoot = resolve("test/live");
+
 for (const target of targets) {
-  if (!/^test\/live\/[A-Za-z0-9._-]+\.test\.ts$/.test(target) || !existsSync(target)) {
+  const relativeTarget = relative(liveRoot, resolve(target));
+  const isLiveTest =
+    target.startsWith("test/live/") &&
+    target.endsWith(".test.ts") &&
+    relativeTarget !== ".." &&
+    !relativeTarget.startsWith(`..${sep}`);
+
+  if (!isLiveTest || !existsSync(target)) {
     throw new Error(`Unsupported live test target: ${target}`);
   }
 }
 
 const { createPutioSdkPromiseClient } = await import("../dist/index.js");
-const createClient = async (config: Record<string, unknown> = {}) =>
-  createPutioSdkPromiseClient(config);
+const clients = new Set<ReturnType<typeof createPutioSdkPromiseClient>>();
+const createClient = async (config: Record<string, unknown> = {}) => {
+  const client = createPutioSdkPromiseClient(config);
+  clients.add(client);
+  return client;
+};
 const secrets = readBootstrapSecrets();
-const firstParty = await bootstrapFirstPartyToken(secrets, createClient);
+let firstParty: Awaited<ReturnType<typeof bootstrapFirstPartyToken>> | null = null;
 let cleanupError: Error | null = null;
 let runError: Error | null = null;
 let status = 1;
 
 try {
+  firstParty = await bootstrapFirstPartyToken(secrets, createClient);
   const thirdParty = await bootstrapThirdPartyToken(
     firstParty.accessToken,
     secrets.thirdPartyClientId,
@@ -49,19 +64,22 @@ try {
 } catch (error) {
   runError = error instanceof Error ? error : new Error("Unknown live test failure");
 } finally {
-  const cleanupClient = createPutioSdkPromiseClient({ accessToken: firstParty.accessToken });
-
   try {
-    if (firstParty.tokenId === null) {
-      cleanupError = new Error("Fresh first-party session did not return a token ID");
-    } else {
-      await cleanupClient.auth.revokeClient(firstParty.tokenId);
+    if (firstParty !== null) {
+      if (firstParty.tokenId === null) {
+        cleanupError = new Error("Fresh first-party session did not return a token ID");
+      } else {
+        const cleanupClient = await createClient({ accessToken: firstParty.accessToken });
+        await cleanupClient.auth.revokeClient(firstParty.tokenId);
+      }
     }
   } catch (error) {
     cleanupError = error instanceof Error ? error : new Error("Unknown token cleanup failure");
-  } finally {
+  }
+
+  for (const client of clients) {
     try {
-      await cleanupClient.dispose();
+      await client.dispose();
     } catch (error) {
       cleanupError ??=
         error instanceof Error ? error : new Error("Unknown client disposal failure");

--- a/scripts/test-live-fresh.ts
+++ b/scripts/test-live-fresh.ts
@@ -1,0 +1,81 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+import {
+  bootstrapFirstPartyToken,
+  bootstrapThirdPartyToken,
+} from "../test/live/support/bootstrap.ts";
+import { readBootstrapSecrets } from "../test/live/support/secrets.ts";
+
+const args = process.argv.slice(2);
+const targets = args[0] === "--" ? args.slice(1) : args;
+
+if (targets.length === 0) {
+  throw new Error("Pass one or more explicit test/live/*.test.ts files");
+}
+
+for (const target of targets) {
+  if (!/^test\/live\/[A-Za-z0-9._-]+\.test\.ts$/.test(target) || !existsSync(target)) {
+    throw new Error(`Unsupported live test target: ${target}`);
+  }
+}
+
+const { createPutioSdkPromiseClient } = await import("../dist/index.js");
+const createClient = async (config: Record<string, unknown> = {}) =>
+  createPutioSdkPromiseClient(config);
+const secrets = readBootstrapSecrets();
+const firstParty = await bootstrapFirstPartyToken(secrets, createClient);
+let cleanupError: Error | null = null;
+let runError: Error | null = null;
+let status = 1;
+
+try {
+  const thirdParty = await bootstrapThirdPartyToken(
+    firstParty.accessToken,
+    secrets.thirdPartyClientId,
+    createClient,
+  );
+  const result = spawnSync("vp", ["test", "run", "--config", "vitest.live.config.ts", ...targets], {
+    env: {
+      ...process.env,
+      PUTIO_TOKEN_FIRST_PARTY: firstParty.accessToken,
+      PUTIO_TOKEN_THIRD_PARTY: thirdParty.accessToken,
+    },
+    stdio: "inherit",
+  });
+
+  runError = result.error ?? null;
+  status = result.status ?? 1;
+} catch (error) {
+  runError = error instanceof Error ? error : new Error("Unknown live test failure");
+} finally {
+  const cleanupClient = createPutioSdkPromiseClient({ accessToken: firstParty.accessToken });
+
+  try {
+    if (firstParty.tokenId === null) {
+      cleanupError = new Error("Fresh first-party session did not return a token ID");
+    } else {
+      await cleanupClient.auth.revokeClient(firstParty.tokenId);
+    }
+  } catch (error) {
+    cleanupError = error instanceof Error ? error : new Error("Unknown token cleanup failure");
+  } finally {
+    try {
+      await cleanupClient.dispose();
+    } catch (error) {
+      cleanupError ??=
+        error instanceof Error ? error : new Error("Unknown client disposal failure");
+    }
+  }
+}
+
+if (runError) {
+  console.error(`Live test execution failed: ${runError.message}`);
+}
+
+if (cleanupError) {
+  console.error(`Fresh token cleanup failed: ${cleanupError.message}`);
+  process.exit(1);
+}
+
+process.exit(status);

--- a/test/live/support/bootstrap.ts
+++ b/test/live/support/bootstrap.ts
@@ -179,30 +179,46 @@ export const bootstrapFirstPartyTokenWithCredentials = async (
   });
 
   let accessToken = loginResult.access_token;
-  let validation = await resolvedSdk.auth.validateToken(accessToken);
 
-  if (validation.token_scope === "two_factor") {
-    accessToken = await verifyTwoFactorToken(
+  try {
+    let validation = await resolvedSdk.auth.validateToken(accessToken);
+
+    if (validation.token_scope === "two_factor") {
+      accessToken = await verifyTwoFactorToken(
+        accessToken,
+        {
+          credentials,
+          firstPartyClient,
+        } as PutioBootstrapSecrets,
+        createClient,
+      );
+      validation = await resolvedSdk.auth.validateToken(accessToken);
+    }
+
+    if (validation.result !== true) {
+      throw new Error("first-party token validation did not succeed");
+    }
+
+    return {
       accessToken,
-      {
-        credentials,
-        firstPartyClient,
-      } as PutioBootstrapSecrets,
-      createClient,
-    );
-    validation = await resolvedSdk.auth.validateToken(accessToken);
-  }
+      scope: validation.token_scope,
+      tokenId: validation.token_id,
+      userId: validation.user_id,
+    };
+  } catch (error) {
+    resolvedSdk.setAccessToken(accessToken);
 
-  if (validation.result !== true) {
-    throw new Error("first-party token validation did not succeed");
-  }
+    try {
+      await resolvedSdk.auth.logout();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "First-party token bootstrap failed and its session could not be revoked",
+      );
+    }
 
-  return {
-    accessToken,
-    scope: validation.token_scope,
-    tokenId: validation.token_id,
-    userId: validation.user_id,
-  };
+    throw error;
+  }
 };
 
 export const bootstrapThirdPartyToken = async (


### PR DESCRIPTION
## Summary

Add one focused command for live SDK tests that creates runtime credentials,
runs only explicit targets, and revokes the fresh first-party session before
exit.

Part of #108 (deferred contract/live confidence lane). Replaces the closed #150
with a smaller repository-native implementation.

## Changed

- add `pnpm test:live:fresh -- <test/live/*.test.ts...>`
- reuse the existing live bootstrap helpers and built SDK
- pass runtime tokens only to the test child process
- revoke the fresh first-party session in cleanup, including after failures
- document direct Infisical machine-identity injection without storing
  `INFISICAL_TOKEN`

## Review aids

Sanitized behavior proof:

```text
$ pnpm test:live:fresh -- test/live/account.test.ts test/live/tunnel.test.ts
Test Files  2 passed (2)
Tests       9 passed (9)
exit 0 (including session revocation)
```

The implementation is one script: `scripts/test-live-fresh.ts`.

## Risks

- live execution remains opt-in and requires maintainer credentials
- third-party OAuth app/token bootstrap retains the existing fixture behavior;
  this change only makes the first-party login session fresh and explicitly
  revoked
- no public PR CI or scheduled lane is added here

## Verification

- `pnpm exec vp run verify`
- `pnpm exec vp run lint:package`
- `pnpm test:live:fresh -- test/live/account.test.ts test/live/tunnel.test.ts`
- explicit-target failure path via `pnpm test:live:fresh`
- `git diff --check`

## Complexity

One 81-line script, one package command, and focused environment/testing
documentation. No lifecycle framework, custom evidence format, CI changes, or
agent-specific code.
