### PR TITLE
fix(validation): reject excess request properties

### DIFF
--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -10,7 +10,7 @@ export const decodeAndRun = <S extends Schema.Top, A, E, R>(
   input: unknown,
   run: (decoded: S["Type"]) => Effect.Effect<A, E, R>,
 ) =>
-  Schema.decodeUnknownEffect(schema)(input).pipe(
+  Schema.decodeUnknownEffect(schema, { onExcessProperty: "error" })(input).pipe(
     Effect.mapError(mapDecodeErrorToValidationError),
     Effect.flatMap(run),
   );

--- a/src/domains/ops.spec.ts
+++ b/src/domains/ops.spec.ts
@@ -1218,6 +1218,8 @@ describe("operational domain boundaries", () => {
       // @ts-expect-error JavaScript callers can provide null instead of a query object.
       runSdkExit(trash.listTrash(null), handler),
       runSdkExit(trash.listTrash({ per_page: 0 }), handler),
+      // @ts-expect-error JavaScript callers can provide unknown query properties.
+      runSdkExit(trash.listTrash({ unexpected: true }), handler),
       runSdkExit(trash.continueTrash(""), handler),
       runSdkExit(trash.continueTrash("cursor", { per_page: 0 }), handler),
       // @ts-expect-error JavaScript callers can provide null instead of a query object.
@@ -1247,6 +1249,8 @@ describe("operational domain boundaries", () => {
       runSdkExit(zips.createZip({ file_ids: [] }), handler),
       runSdkExit(zips.createZip({ file_ids: [0] }), handler),
       runSdkExit(zips.createZip({ cursor: "cursor", exclude_ids: [0] }), handler),
+      // @ts-expect-error JavaScript callers can provide unknown request properties.
+      runSdkExit(zips.createZip({ file_ids: [1], unexpected: true }), handler),
       runSdkExit(zips.getZip(0), handler),
       runSdkExit(zips.cancelZip(0), handler),
     ]);


### PR DESCRIPTION
## Summary

Make the shared request-decoding boundary reject excess object properties instead of silently stripping them.

Part of #108.

## Changed

- set `onExcessProperty: "error"` in `decodeAndRun`
- cover excess query and request properties through trash and zip operations
- prove rejected inputs perform zero transport calls

## Review aids

Sanitized contract example:

```ts
trash.list({ unexpected: true })
// PutioValidationError; transport calls: 0
```

## Risks

JavaScript callers passing undocumented keys to operations backed by `decodeAndRun` now receive `PutioValidationError` instead of having those keys discarded.

## Verification

- focused operational boundary suite: 10 tests passed
- full deterministic suite: 22 files, 131 tests passed
- Knip source check passed
