### PR TITLE
fix(transfers): validate outbound requests

### DIFF
--- a/src/domains/ops.spec.ts
+++ b/src/domains/ops.spec.ts
@@ -1170,7 +1170,50 @@ describe("operational domain boundaries", () => {
       return jsonResponse({ status: "OK" });
     };
     const failures = await Promise.all([
+      // @ts-expect-error JavaScript callers can provide null instead of a query object.
+      runSdkExit(transfers.listTransfers(null), handler, { accessToken: "token-123" }),
+      runSdkExit(transfers.listTransfers({ per_page: 0 }), handler, {
+        accessToken: "token-123",
+      }),
+      runSdkExit(transfers.listTransfers({ per_page: 1.5 }), handler, {
+        accessToken: "token-123",
+      }),
+      runSdkExit(transfers.continueTransfers(""), handler, { accessToken: "token-123" }),
+      // @ts-expect-error JavaScript callers can provide null instead of a query object.
+      runSdkExit(transfers.continueTransfers("cursor", null), handler, {
+        accessToken: "token-123",
+      }),
+      runSdkExit(transfers.continueTransfers("cursor", { per_page: 0 }), handler, {
+        accessToken: "token-123",
+      }),
+      runSdkExit(transfers.getTransfer(0), handler, { accessToken: "token-123" }),
       runSdkExit(transfers.getTransferTorrent(0), handler, { accessToken: "token-123" }),
+      runSdkExit(transfers.getTransferInfo([]), handler, { accessToken: "token-123" }),
+      runSdkExit(
+        transfers.getTransferInfo(["https://example.com/a\nhttps://example.com/b"]),
+        handler,
+        {
+          accessToken: "token-123",
+        },
+      ),
+      runSdkExit(transfers.addTransfer({ url: "" }), handler, { accessToken: "token-123" }),
+      runSdkExit(
+        transfers.addTransfer({ save_parent_id: -1, url: "https://example.com" }),
+        handler,
+        {
+          accessToken: "token-123",
+        },
+      ),
+      runSdkExit(
+        // @ts-expect-error JavaScript callers can provide unknown request properties.
+        transfers.addTransfer({ unexpected: true, url: "https://example.com" }),
+        handler,
+        { accessToken: "token-123" },
+      ),
+      runSdkExit(transfers.addManyTransfers([]), handler, { accessToken: "token-123" }),
+      runSdkExit(transfers.addManyTransfers([{ url: "" }]), handler, {
+        accessToken: "token-123",
+      }),
       runSdkExit(transfers.addTransferTrackers({ trackers: [], transferId: 1 }), handler, {
         accessToken: "token-123",
       }),
@@ -1182,6 +1225,9 @@ describe("operational domain boundaries", () => {
         handler,
         { accessToken: "token-123" },
       ),
+      runSdkExit(transfers.cancelTransfers([]), handler, { accessToken: "token-123" }),
+      runSdkExit(transfers.cancelTransfers([0]), handler, { accessToken: "token-123" }),
+      runSdkExit(transfers.cleanTransfers([-1]), handler, { accessToken: "token-123" }),
       runSdkExit(transfers.removeTransfers({ ids: [] }), handler, {
         accessToken: "token-123",
       }),
@@ -1200,6 +1246,15 @@ describe("operational domain boundaries", () => {
         handler,
         { accessToken: "token-123" },
       ),
+      runSdkExit(
+        // @ts-expect-error JavaScript callers can provide unsupported filter literals.
+        transfers.removeTransfers({ filter: "pending" }),
+        handler,
+        { accessToken: "token-123" },
+      ),
+      runSdkExit(transfers.retryTransfer(0), handler, { accessToken: "token-123" }),
+      runSdkExit(transfers.reannounceTransfer(0), handler, { accessToken: "token-123" }),
+      runSdkExit(transfers.stopTransferRecording(0), handler, { accessToken: "token-123" }),
     ]);
 
     expect(

--- a/src/domains/transfers.ts
+++ b/src/domains/transfers.ts
@@ -2,7 +2,6 @@ import { Effect, Schema } from "effect";
 import { joinCsv } from "../core/forms.js";
 import { NonEmptyStringSchema, PositiveIntegerSchema, decodeAndRun } from "../core/validation.js";
 import {
-  PutioValidationError,
   definePutioOperationErrorSpec,
   withOperationErrors,
   type PutioOperationFailure,
@@ -345,11 +344,7 @@ export type StopRecordingTransferError = PutioOperationFailure<
 >;
 export const listTransfers = (
   query: TransfersListQuery = {},
-): Effect.Effect<
-  TransfersListResponse,
-  ListTransfersError | PutioValidationError,
-  PutioSdkContext
-> =>
+): Effect.Effect<TransfersListResponse, ListTransfersError, PutioSdkContext> =>
   decodeAndRun(TransfersListQuerySchema, query, (decodedQuery) =>
     requestJson(TransfersListEnvelopeSchema, {
       method: "GET",
@@ -360,11 +355,7 @@ export const listTransfers = (
 export const continueTransfers = (
   cursor: string,
   query: TransfersListQuery = {},
-): Effect.Effect<
-  TransfersContinueResponse,
-  ListTransfersError | PutioValidationError,
-  PutioSdkContext
-> =>
+): Effect.Effect<TransfersContinueResponse, ListTransfersError, PutioSdkContext> =>
   decodeAndRun(TransferContinueInputSchema, { cursor, query }, (decodedInput) =>
     requestJson(TransfersContinueEnvelopeSchema, {
       body: {
@@ -380,7 +371,7 @@ export const continueTransfers = (
   ).pipe(withOperationErrors(ListTransfersErrorSpec));
 export const getTransfer = (
   id: number,
-): Effect.Effect<Transfer, GetTransferError | PutioValidationError, PutioSdkContext> =>
+): Effect.Effect<Transfer, GetTransferError, PutioSdkContext> =>
   decodeAndRun(TransferIdSchema, id, (decodedId) =>
     requestJson(TransferEnvelopeSchema, {
       method: "GET",
@@ -389,7 +380,7 @@ export const getTransfer = (
   ).pipe(withOperationErrors(GetTransferErrorSpec));
 export const getTransferTorrent = (
   id: number,
-): Effect.Effect<Uint8Array, GetTransferTorrentError | PutioValidationError, PutioSdkContext> =>
+): Effect.Effect<Uint8Array, GetTransferTorrentError, PutioSdkContext> =>
   decodeAndRun(TransferIdSchema, id, (decodedId) =>
     requestArrayBuffer({
       method: "GET",
@@ -425,7 +416,7 @@ export const getTransferInfo = (
   );
 export const addTransfer = (
   input: TransferAddInput,
-): Effect.Effect<Transfer, AddTransferError | PutioValidationError, PutioSdkContext> =>
+): Effect.Effect<Transfer, AddTransferError, PutioSdkContext> =>
   decodeAndRun(TransferAddInputSchema, input, (decodedInput) =>
     requestJson(TransferEnvelopeSchema, {
       body: {
@@ -443,7 +434,7 @@ export const addManyTransfers = (
     readonly errors: ReadonlyArray<TransfersAddMultiError>;
     readonly transfers: ReadonlyArray<Transfer>;
   },
-  AddManyTransfersError | PutioValidationError,
+  AddManyTransfersError,
   PutioSdkContext
 > =>
   decodeAndRun(TransferAddManyInputSchema, inputs, (decodedInputs) =>
@@ -460,7 +451,7 @@ export const addManyTransfers = (
   ).pipe(withOperationErrors(AddManyTransfersErrorSpec));
 export const addTransferTrackers = (
   input: TransferAddTrackersInput,
-): Effect.Effect<void, AddTransferTrackersError | PutioValidationError, PutioSdkContext> =>
+): Effect.Effect<void, AddTransferTrackersError, PutioSdkContext> =>
   decodeAndRun(TransferAddTrackersInputSchema, input, (decodedInput) =>
     requestJson(OkResponseSchema, {
       body: {
@@ -509,7 +500,7 @@ export const cleanTransfers = (
   );
 export const removeTransfers = (
   input: TransferRemoveInput,
-): Effect.Effect<void, RemoveTransfersError | PutioValidationError, PutioSdkContext> =>
+): Effect.Effect<void, RemoveTransfersError, PutioSdkContext> =>
   decodeAndRun(TransferRemoveInputSchema, input, (decodedInput) =>
     requestJson(OkResponseSchema, {
       body: {
@@ -525,7 +516,7 @@ export const removeTransfers = (
   ).pipe(Effect.asVoid, withOperationErrors(RemoveTransfersErrorSpec));
 export const retryTransfer = (
   id: number,
-): Effect.Effect<Transfer, RetryTransferError | PutioValidationError, PutioSdkContext> =>
+): Effect.Effect<Transfer, RetryTransferError, PutioSdkContext> =>
   decodeAndRun(TransferIdSchema, id, (decodedId) =>
     requestJson(TransferEnvelopeSchema, {
       body: {
@@ -542,7 +533,7 @@ export const reannounceTransfer = (
   id: number,
 ): Effect.Effect<
   Schema.Schema.Type<typeof OkResponseSchema>,
-  ReannounceTransferError | PutioValidationError,
+  ReannounceTransferError,
   PutioSdkContext
 > =>
   decodeAndRun(TransferIdSchema, id, (decodedId) =>
@@ -561,7 +552,7 @@ export const stopTransferRecording = (
   id: number,
 ): Effect.Effect<
   Schema.Schema.Type<typeof OkResponseSchema>,
-  StopRecordingTransferError | PutioValidationError,
+  StopRecordingTransferError,
   PutioSdkContext
 > =>
   decodeAndRun(TransferIdSchema, id, (decodedId) =>

--- a/src/domains/transfers.ts
+++ b/src/domains/transfers.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect";
 import { joinCsv } from "../core/forms.js";
+import { NonEmptyStringSchema, PositiveIntegerSchema, decodeAndRun } from "../core/validation.js";
 import {
-  mapDecodeErrorToValidationError,
   PutioValidationError,
   definePutioOperationErrorSpec,
   withOperationErrors,
@@ -17,7 +17,7 @@ import {
   selectJsonFields,
   type PutioSdkContext,
 } from "../core/http.js";
-const TransferIdSchema = Schema.Int.check(Schema.isGreaterThan(0));
+const TransferIdSchema = PositiveIntegerSchema;
 const TransferIdsSchema = Schema.Array(TransferIdSchema).check(Schema.isMinLength(1));
 export const TransferTypeSchema = Schema.Literals([
   "URL",
@@ -136,13 +136,26 @@ export const TransferSchema = Schema.Union([
   TransferBaseSchema,
 ]);
 export const TransfersListQuerySchema = Schema.Struct({
-  per_page: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
+  per_page: Schema.optional(PositiveIntegerSchema),
 });
 export const TransferAddInputSchema = Schema.Struct({
-  callback_url: Schema.optional(Schema.String),
-  save_parent_id: Schema.optional(Schema.Int),
-  url: Schema.String,
+  callback_url: Schema.optional(NonEmptyStringSchema),
+  save_parent_id: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  url: NonEmptyStringSchema,
 });
+const TransferContinueInputSchema = Schema.Struct({
+  cursor: NonEmptyStringSchema,
+  query: TransfersListQuerySchema,
+});
+const TransferInfoUrlSchema = Schema.String.check(
+  Schema.isMinLength(1),
+  Schema.isPattern(/^[^\r\n]+$/),
+);
+const TransferInfoUrlsSchema = Schema.Array(TransferInfoUrlSchema).check(Schema.isMinLength(1));
+const TransferAddManyInputSchema = Schema.Array(TransferAddInputSchema).check(
+  Schema.isMinLength(1),
+);
+const TransferCleanIdsSchema = Schema.Array(TransferIdSchema);
 const TrackerSchema = Schema.String.check(Schema.isPattern(/^[^,\s]+$/));
 export const TransferAddTrackersInputSchema = Schema.Struct({
   trackers: Schema.Array(TrackerSchema).check(Schema.isMinLength(1)),
@@ -332,49 +345,57 @@ export type StopRecordingTransferError = PutioOperationFailure<
 >;
 export const listTransfers = (
   query: TransfersListQuery = {},
-): Effect.Effect<TransfersListResponse, ListTransfersError, PutioSdkContext> =>
-  requestJson(TransfersListEnvelopeSchema, {
-    method: "GET",
-    path: "/v2/transfers/list",
-    query,
-  }).pipe(withOperationErrors(ListTransfersErrorSpec));
+): Effect.Effect<
+  TransfersListResponse,
+  ListTransfersError | PutioValidationError,
+  PutioSdkContext
+> =>
+  decodeAndRun(TransfersListQuerySchema, query, (decodedQuery) =>
+    requestJson(TransfersListEnvelopeSchema, {
+      method: "GET",
+      path: "/v2/transfers/list",
+      query: decodedQuery,
+    }),
+  ).pipe(withOperationErrors(ListTransfersErrorSpec));
 export const continueTransfers = (
   cursor: string,
-  query: {
-    readonly per_page?: number;
-  } = {},
-): Effect.Effect<TransfersContinueResponse, ListTransfersError, PutioSdkContext> =>
-  requestJson(TransfersContinueEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: {
-        cursor,
+  query: TransfersListQuery = {},
+): Effect.Effect<
+  TransfersContinueResponse,
+  ListTransfersError | PutioValidationError,
+  PutioSdkContext
+> =>
+  decodeAndRun(TransferContinueInputSchema, { cursor, query }, (decodedInput) =>
+    requestJson(TransfersContinueEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: {
+          cursor: decodedInput.cursor,
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/transfers/list/continue",
-    query,
-  }).pipe(withOperationErrors(ListTransfersErrorSpec));
+      method: "POST",
+      path: "/v2/transfers/list/continue",
+      query: decodedInput.query,
+    }),
+  ).pipe(withOperationErrors(ListTransfersErrorSpec));
 export const getTransfer = (
   id: number,
-): Effect.Effect<Transfer, GetTransferError, PutioSdkContext> =>
-  requestJson(TransferEnvelopeSchema, {
-    method: "GET",
-    path: `/v2/transfers/${encodePathSegment(id)}`,
-  }).pipe(selectJsonField("transfer"), withOperationErrors(GetTransferErrorSpec));
+): Effect.Effect<Transfer, GetTransferError | PutioValidationError, PutioSdkContext> =>
+  decodeAndRun(TransferIdSchema, id, (decodedId) =>
+    requestJson(TransferEnvelopeSchema, {
+      method: "GET",
+      path: `/v2/transfers/${encodePathSegment(decodedId)}`,
+    }).pipe(selectJsonField("transfer")),
+  ).pipe(withOperationErrors(GetTransferErrorSpec));
 export const getTransferTorrent = (
   id: number,
 ): Effect.Effect<Uint8Array, GetTransferTorrentError | PutioValidationError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(TransferIdSchema)(id).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedId) =>
-      requestArrayBuffer({
-        method: "GET",
-        path: `/v2/transfers/${encodePathSegment(decodedId)}/torrent`,
-      }),
-    ),
-    withOperationErrors(GetTransferTorrentErrorSpec),
-  );
+  decodeAndRun(TransferIdSchema, id, (decodedId) =>
+    requestArrayBuffer({
+      method: "GET",
+      path: `/v2/transfers/${encodePathSegment(decodedId)}/torrent`,
+    }),
+  ).pipe(withOperationErrors(GetTransferTorrentErrorSpec));
 export const countTransfers = (): Effect.Effect<number, PutioSdkError, PutioSdkContext> =>
   requestJson(TransferCountEnvelopeSchema, {
     method: "GET",
@@ -390,27 +411,31 @@ export const getTransferInfo = (
   PutioSdkError,
   PutioSdkContext
 > =>
-  requestJson(TransferInfoEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: {
-        urls: urls.join("\n"),
+  decodeAndRun(TransferInfoUrlsSchema, urls, (decodedUrls) =>
+    requestJson(TransferInfoEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: {
+          urls: decodedUrls.join("\n"),
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/transfers/info",
-  }).pipe(selectJsonFields("disk_avail", "ret"));
+      method: "POST",
+      path: "/v2/transfers/info",
+    }).pipe(selectJsonFields("disk_avail", "ret")),
+  );
 export const addTransfer = (
   input: TransferAddInput,
-): Effect.Effect<Transfer, AddTransferError, PutioSdkContext> =>
-  requestJson(TransferEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: input,
-    },
-    method: "POST",
-    path: "/v2/transfers/add",
-  }).pipe(selectJsonField("transfer"), withOperationErrors(AddTransferErrorSpec));
+): Effect.Effect<Transfer, AddTransferError | PutioValidationError, PutioSdkContext> =>
+  decodeAndRun(TransferAddInputSchema, input, (decodedInput) =>
+    requestJson(TransferEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: decodedInput,
+      },
+      method: "POST",
+      path: "/v2/transfers/add",
+    }).pipe(selectJsonField("transfer")),
+  ).pipe(withOperationErrors(AddTransferErrorSpec));
 export const addManyTransfers = (
   inputs: ReadonlyArray<TransferAddInput>,
 ): Effect.Effect<
@@ -418,52 +443,51 @@ export const addManyTransfers = (
     readonly errors: ReadonlyArray<TransfersAddMultiError>;
     readonly transfers: ReadonlyArray<Transfer>;
   },
-  AddManyTransfersError,
+  AddManyTransfersError | PutioValidationError,
   PutioSdkContext
 > =>
-  requestJson(TransfersAddMultiEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: {
-        urls: JSON.stringify(inputs),
+  decodeAndRun(TransferAddManyInputSchema, inputs, (decodedInputs) =>
+    requestJson(TransfersAddMultiEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: {
+          urls: JSON.stringify(decodedInputs),
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/transfers/add-multi",
-  }).pipe(selectJsonFields("errors", "transfers"), withOperationErrors(AddManyTransfersErrorSpec));
+      method: "POST",
+      path: "/v2/transfers/add-multi",
+    }).pipe(selectJsonFields("errors", "transfers")),
+  ).pipe(withOperationErrors(AddManyTransfersErrorSpec));
 export const addTransferTrackers = (
   input: TransferAddTrackersInput,
 ): Effect.Effect<void, AddTransferTrackersError | PutioValidationError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(TransferAddTrackersInputSchema)(input).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedInput) =>
-      requestJson(OkResponseSchema, {
-        body: {
-          type: "form",
-          value: {
-            trackers: joinCsv(decodedInput.trackers),
-          },
+  decodeAndRun(TransferAddTrackersInputSchema, input, (decodedInput) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value: {
+          trackers: joinCsv(decodedInput.trackers),
         },
-        method: "POST",
-        path: `/v2/transfers/add-trackers/${encodePathSegment(decodedInput.transferId)}`,
-      }),
-    ),
-    Effect.asVoid,
-    withOperationErrors(AddTransferTrackersErrorSpec),
-  );
+      },
+      method: "POST",
+      path: `/v2/transfers/add-trackers/${encodePathSegment(decodedInput.transferId)}`,
+    }),
+  ).pipe(Effect.asVoid, withOperationErrors(AddTransferTrackersErrorSpec));
 export const cancelTransfers = (
   ids: ReadonlyArray<number>,
 ): Effect.Effect<Schema.Schema.Type<typeof OkResponseSchema>, PutioSdkError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: {
-        transfer_ids: joinCsv(ids),
+  decodeAndRun(TransferIdsSchema, ids, (decodedIds) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value: {
+          transfer_ids: joinCsv(decodedIds),
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/transfers/cancel",
-  });
+      method: "POST",
+      path: "/v2/transfers/cancel",
+    }),
+  );
 export const cleanTransfers = (
   ids: ReadonlyArray<number> = [],
 ): Effect.Effect<
@@ -473,79 +497,82 @@ export const cleanTransfers = (
   PutioSdkError,
   PutioSdkContext
 > =>
-  requestJson(TransfersCleanEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: ids.length > 0 ? { transfer_ids: joinCsv(ids) } : {},
-    },
-    method: "POST",
-    path: "/v2/transfers/clean",
-  }).pipe(selectJsonFields("deleted_ids"));
+  decodeAndRun(TransferCleanIdsSchema, ids, (decodedIds) =>
+    requestJson(TransfersCleanEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: decodedIds.length > 0 ? { transfer_ids: joinCsv(decodedIds) } : {},
+      },
+      method: "POST",
+      path: "/v2/transfers/clean",
+    }).pipe(selectJsonFields("deleted_ids")),
+  );
 export const removeTransfers = (
   input: TransferRemoveInput,
 ): Effect.Effect<void, RemoveTransfersError | PutioValidationError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(TransferRemoveInputSchema)(input).pipe(
-    Effect.mapError(mapDecodeErrorToValidationError),
-    Effect.flatMap((decodedInput) =>
-      requestJson(OkResponseSchema, {
-        body: {
-          type: "form",
-          value:
-            decodedInput.ids !== undefined
-              ? { transfer_ids: joinCsv(decodedInput.ids) }
-              : { remove_filter: decodedInput.filter },
-        },
-        method: "POST",
-        path: "/v2/transfers/remove",
-      }),
-    ),
-    Effect.asVoid,
-    withOperationErrors(RemoveTransfersErrorSpec),
-  );
+  decodeAndRun(TransferRemoveInputSchema, input, (decodedInput) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value:
+          decodedInput.ids !== undefined
+            ? { transfer_ids: joinCsv(decodedInput.ids) }
+            : { remove_filter: decodedInput.filter },
+      },
+      method: "POST",
+      path: "/v2/transfers/remove",
+    }),
+  ).pipe(Effect.asVoid, withOperationErrors(RemoveTransfersErrorSpec));
 export const retryTransfer = (
   id: number,
-): Effect.Effect<Transfer, RetryTransferError, PutioSdkContext> =>
-  requestJson(TransferEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: {
-        id,
+): Effect.Effect<Transfer, RetryTransferError | PutioValidationError, PutioSdkContext> =>
+  decodeAndRun(TransferIdSchema, id, (decodedId) =>
+    requestJson(TransferEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: {
+          id: decodedId,
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/transfers/retry",
-  }).pipe(selectJsonField("transfer"), withOperationErrors(RetryTransferErrorSpec));
+      method: "POST",
+      path: "/v2/transfers/retry",
+    }).pipe(selectJsonField("transfer")),
+  ).pipe(withOperationErrors(RetryTransferErrorSpec));
 export const reannounceTransfer = (
   id: number,
 ): Effect.Effect<
   Schema.Schema.Type<typeof OkResponseSchema>,
-  ReannounceTransferError,
+  ReannounceTransferError | PutioValidationError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: {
-        id,
+  decodeAndRun(TransferIdSchema, id, (decodedId) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value: {
+          id: decodedId,
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/transfers/reannounce",
-  }).pipe(withOperationErrors(ReannounceTransferErrorSpec));
+      method: "POST",
+      path: "/v2/transfers/reannounce",
+    }),
+  ).pipe(withOperationErrors(ReannounceTransferErrorSpec));
 export const stopTransferRecording = (
   id: number,
 ): Effect.Effect<
   Schema.Schema.Type<typeof OkResponseSchema>,
-  StopRecordingTransferError,
+  StopRecordingTransferError | PutioValidationError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: {
-        transfer_id: id,
+  decodeAndRun(TransferIdSchema, id, (decodedId) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value: {
+          transfer_id: decodedId,
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/transfers/stop-recording",
-  }).pipe(withOperationErrors(StopRecordingTransferErrorSpec));
+      method: "POST",
+      path: "/v2/transfers/stop-recording",
+    }),
+  ).pipe(withOperationErrors(StopRecordingTransferErrorSpec));


### PR DESCRIPTION
## Summary

Validate every public transfer operation that serializes path, query, form, or JSON input before transport.

Part of #108. Stacked on #153.

## Changed

- validate list/continue pagination and cursors
- validate transfer IDs, ID arrays, URL arrays, add payloads, multi-add payloads, trackers, and remove filters
- reject empty, fractional, negative, newline-delimited, unsupported-literal, nested-invalid, and excess-property inputs
- preserve existing form, CSV, newline-list, JSON, and path serialization after decoding
- expose `PutioValidationError` in operation error channels where needed

## Review aids

Sanitized boundary examples:

```ts
transfers.addMany([{ url: "" }])
transfers.remove({ filter: "pending" })
transfers.info(["https://example.test/a\nhttps://example.test/b"])
// each fails with PutioValidationError; transport calls: 0
```

## Risks

Previously forwarded invalid runtime inputs now fail locally. Valid request serialization and public success types are unchanged.

## Verification

- focused operational boundary suite: 10 tests passed
- full deterministic suite: 22 files, 131 tests passed
- Knip source check passed
