### PR TITLE
fix(auth): validate outbound requests

### DIFF
--- a/src/domains/auth.spec.ts
+++ b/src/domains/auth.spec.ts
@@ -406,6 +406,70 @@ describe("auth domain", () => {
     });
   });
 
+  it("rejects invalid auth inputs before transport without exposing credentials", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+    const sensitiveSecret = "sensitive-client-secret";
+    const sensitivePassword = "sensitive-password";
+    const failures = await Promise.all([
+      runSdkExit(
+        login({
+          clientId: 42,
+          clientSecret: sensitiveSecret,
+          password: sensitivePassword,
+          username: "",
+        }),
+        handler,
+      ),
+      runSdkExit(
+        register({
+          client_id: 42,
+          mail: "sdk@put.io",
+          password: sensitivePassword,
+          username: "",
+        }),
+        handler,
+      ),
+      runSdkExit(
+        register({
+          client_id: 42,
+          mail: "sdk@put.io",
+          password: sensitivePassword,
+          // @ts-expect-error JavaScript callers can provide unknown request properties.
+          unexpected: true,
+          username: "sdk",
+        }),
+        handler,
+      ),
+      runSdkExit(exists("username", ""), handler),
+      // @ts-expect-error JavaScript callers can provide unsupported lookup keys.
+      runSdkExit(exists("phone", "sdk"), handler),
+      runSdkExit(getVoucher(""), handler),
+      runSdkExit(getGiftCard(""), handler),
+      runSdkExit(getFamilyInvite(""), handler),
+      runSdkExit(getFriendInvite(""), handler),
+      runSdkExit(forgotPassword(""), handler),
+      runSdkExit(resetPassword("", sensitivePassword), handler),
+      runSdkExit(getCode({ appId: 0 }), handler),
+      runSdkExit(checkCodeMatch(""), handler),
+      runSdkExit(linkDevice(""), handler),
+      runSdkExit(revokeApp(0), handler),
+      runSdkExit(revokeClient(1.5), handler),
+      runSdkExit(validateToken(""), handler),
+      runSdkExit(verifyTOTP("", "123456"), handler),
+      runSdkExit(verifyTOTP("temporary-token", ""), handler),
+    ]);
+
+    const errors = failures.map(expectFailure);
+    expect(errors.every((error) => error instanceof PutioValidationError)).toBe(true);
+    expect(JSON.stringify(errors)).not.toContain(sensitiveSecret);
+    expect(JSON.stringify(errors)).not.toContain(sensitivePassword);
+    expect(requestCount).toBe(0);
+  });
+
   it("maps auth operation errors", async () => {
     const exit = await runSdkExit(
       register({

--- a/src/domains/auth.spec.ts
+++ b/src/domains/auth.spec.ts
@@ -38,6 +38,11 @@ import {
   runSdkExit,
 } from "../../test/support/sdk-test.js";
 
+const renderErrorForSecretCheck = (error: unknown): string =>
+  error instanceof Error
+    ? `${String(error)}\n${error.stack ?? ""}\n${JSON.stringify(error)}`
+    : `${String(error)}\n${JSON.stringify(error)}`;
+
 describe("auth domain", () => {
   it("builds the hosted login URL", () => {
     expect(
@@ -116,7 +121,7 @@ describe("auth domain", () => {
     );
 
     expect(invalid).toBeInstanceOf(PutioValidationError);
-    expect(JSON.stringify(invalid)).not.toContain(sensitiveSecret);
+    expect(renderErrorForSecretCheck(invalid)).not.toContain(sensitiveSecret);
     expect(requestCount).toBe(0);
   });
 
@@ -464,9 +469,10 @@ describe("auth domain", () => {
     ]);
 
     const errors = failures.map(expectFailure);
+    const renderedErrors = errors.map(renderErrorForSecretCheck).join("\n");
     expect(errors.every((error) => error instanceof PutioValidationError)).toBe(true);
-    expect(JSON.stringify(errors)).not.toContain(sensitiveSecret);
-    expect(JSON.stringify(errors)).not.toContain(sensitivePassword);
+    expect(renderedErrors).not.toContain(sensitiveSecret);
+    expect(renderedErrors).not.toContain(sensitivePassword);
     expect(requestCount).toBe(0);
   });
 

--- a/src/domains/auth.ts
+++ b/src/domains/auth.ts
@@ -199,6 +199,7 @@ export type GenerateTOTPResponse = Schema.Schema.Type<typeof GenerateTOTPRespons
 export type VerifyTOTPResponse = Schema.Schema.Type<typeof VerifyTOTPResponseSchema>;
 export type RegisterInput = Schema.Schema.Type<typeof RegisterInputSchema>;
 export type LoginInput = Schema.Schema.Type<typeof LoginInputSchema>;
+export type AuthGetCodeInput = Schema.Schema.Type<typeof AuthGetCodeInputSchema>;
 export type OAuthAuthorizationCodeExchangeInput = Schema.Schema.Type<
   typeof OAuthAuthorizationCodeExchangeInputSchema
 >;
@@ -613,7 +614,7 @@ export const resetPassword = (
       }).pipe(selectJsonFields("access_token")),
   ).pipe(withOperationErrors(ResetPasswordErrorSpec));
 export const getCode = (
-  input: Schema.Schema.Type<typeof AuthGetCodeInputSchema>,
+  input: AuthGetCodeInput,
 ): Effect.Effect<
   Schema.Schema.Type<typeof AuthorizationCodeSchema>,
   PutioSdkError,

--- a/src/domains/auth.ts
+++ b/src/domains/auth.ts
@@ -16,6 +16,7 @@ import {
   selectJsonFields,
   type PutioSdkContext,
 } from "../core/http.js";
+import { NonEmptyStringSchema, PositiveIntegerSchema } from "../core/validation.js";
 import { OAuthAppSchema, OAuthAppSessionSchema } from "./oauth.js";
 export const LoginResponseSchema = Schema.Struct({
   access_token: Schema.String,
@@ -148,25 +149,48 @@ const RecoveryCodesEnvelopeSchema = Schema.Struct({
   recovery_codes: TwoFactorRecoveryCodesSchema,
   status: Schema.Literal("OK"),
 });
+const AuthClientIdSchema = Schema.Union([NonEmptyStringSchema, PositiveIntegerSchema]);
+const LoginInputSchema = Schema.Struct({
+  callbackUrl: Schema.optional(NonEmptyStringSchema),
+  clientId: AuthClientIdSchema,
+  clientName: Schema.optional(NonEmptyStringSchema),
+  clientSecret: NonEmptyStringSchema,
+  fingerprint: Schema.optional(NonEmptyStringSchema),
+  password: NonEmptyStringSchema,
+  username: NonEmptyStringSchema,
+});
 export const RegisterInputSchema = Schema.Struct({
-  client_id: Schema.Union([Schema.String, Schema.Int]),
-  family_invite_code: Schema.optional(Schema.String),
-  friend_invite_code: Schema.optional(Schema.String),
-  gift_card_confirmation_code: Schema.optional(Schema.String),
-  mail: Schema.String,
-  password: Schema.String,
-  plan_name: Schema.optional(Schema.String),
-  username: Schema.String,
-  voucher_code: Schema.optional(Schema.String),
+  client_id: AuthClientIdSchema,
+  family_invite_code: Schema.optional(NonEmptyStringSchema),
+  friend_invite_code: Schema.optional(NonEmptyStringSchema),
+  gift_card_confirmation_code: Schema.optional(NonEmptyStringSchema),
+  mail: NonEmptyStringSchema,
+  password: NonEmptyStringSchema,
+  plan_name: Schema.optional(NonEmptyStringSchema),
+  username: NonEmptyStringSchema,
+  voucher_code: Schema.optional(NonEmptyStringSchema),
 });
 export const OAuthAuthorizationCodeExchangeInputSchema = Schema.Struct({
-  clientId: Schema.Union([
-    Schema.String.check(Schema.isMinLength(1)),
-    Schema.Int.check(Schema.isGreaterThan(0)),
-  ]),
-  clientSecret: Schema.String.check(Schema.isMinLength(1)),
-  code: Schema.String.check(Schema.isMinLength(1)),
-  redirectUri: Schema.optional(Schema.String.check(Schema.isMinLength(1))),
+  clientId: AuthClientIdSchema,
+  clientSecret: NonEmptyStringSchema,
+  code: NonEmptyStringSchema,
+  redirectUri: Schema.optional(NonEmptyStringSchema),
+});
+const AuthExistsInputSchema = Schema.Struct({
+  key: Schema.Literals(["mail", "username"]),
+  value: NonEmptyStringSchema,
+});
+const AuthResetPasswordInputSchema = Schema.Struct({
+  key: NonEmptyStringSchema,
+  password: NonEmptyStringSchema,
+});
+const AuthGetCodeInputSchema = Schema.Struct({
+  appId: AuthClientIdSchema,
+  clientName: Schema.optional(NonEmptyStringSchema),
+});
+const AuthVerifyTotpInputSchema = Schema.Struct({
+  code: NonEmptyStringSchema,
+  twoFactorScopedToken: NonEmptyStringSchema,
 });
 export type LoginResponse = Schema.Schema.Type<typeof LoginResponseSchema>;
 export type ValidateTokenResponse = Schema.Schema.Type<typeof ValidateTokenResponseSchema>;
@@ -174,6 +198,7 @@ export type TwoFactorRecoveryCodes = Schema.Schema.Type<typeof TwoFactorRecovery
 export type GenerateTOTPResponse = Schema.Schema.Type<typeof GenerateTOTPResponseSchema>;
 export type VerifyTOTPResponse = Schema.Schema.Type<typeof VerifyTOTPResponseSchema>;
 export type RegisterInput = Schema.Schema.Type<typeof RegisterInputSchema>;
+export type LoginInput = Schema.Schema.Type<typeof LoginInputSchema>;
 export type OAuthAuthorizationCodeExchangeInput = Schema.Schema.Type<
   typeof OAuthAuthorizationCodeExchangeInputSchema
 >;
@@ -330,15 +355,25 @@ export type RecoveryCodesError = PutioOperationFailure<typeof RecoveryCodesError
 export type RegenerateRecoveryCodesError = PutioOperationFailure<
   typeof RegenerateRecoveryCodesErrorSpec
 >;
-export type LoginInput = {
-  readonly clientId: string | number;
-  readonly clientSecret: string;
-  readonly password: string;
-  readonly username: string;
-  readonly callbackUrl?: string;
-  readonly clientName?: string;
-  readonly fingerprint?: string;
-};
+const decodeAuthInput = <S extends Schema.Top, A, E, R>(
+  operation: string,
+  schema: S,
+  input: unknown,
+  run: (decoded: S["Type"]) => Effect.Effect<A, E, R>,
+) =>
+  Schema.decodeUnknownEffect(schema, { onExcessProperty: "error" })(input).pipe(
+    Effect.mapError(
+      () =>
+        new PutioValidationError({
+          cause: {
+            domain: "auth",
+            operation,
+            reason: "Invalid request input",
+          },
+        }),
+    ),
+    Effect.flatMap(run),
+  );
 export const buildAuthLoginUrl = (options: {
   readonly clientId: string | number;
   readonly redirectUri: string;
@@ -372,18 +407,11 @@ const mapOAuthAuthorizationCodeExchangeError = (
 export const exchangeOAuthAuthorizationCode = (
   input: OAuthAuthorizationCodeExchangeInput,
 ): Effect.Effect<string, PutioSdkError | OAuthAuthorizationCodeExchangeError, PutioSdkContext> =>
-  Schema.decodeUnknownEffect(OAuthAuthorizationCodeExchangeInputSchema)(input).pipe(
-    Effect.mapError(
-      () =>
-        new PutioValidationError({
-          cause: {
-            domain: "auth",
-            operation: "exchangeAuthorizationCode",
-            reason: "Invalid request input",
-          },
-        }),
-    ),
-    Effect.flatMap((decodedInput) =>
+  decodeAuthInput(
+    "exchangeAuthorizationCode",
+    OAuthAuthorizationCodeExchangeInputSchema,
+    input,
+    (decodedInput) =>
       requestJson(OAuthAuthorizationCodeResponseSchema, {
         auth: { type: "none" },
         body: {
@@ -402,27 +430,28 @@ export const exchangeOAuthAuthorizationCode = (
         selectJsonField("access_token"),
         Effect.mapError(mapOAuthAuthorizationCodeExchangeError),
       ),
-    ),
   );
 export const login = (
   input: LoginInput,
 ): Effect.Effect<LoginResponse, LoginError, PutioSdkContext> =>
-  requestJson(LoginResponseSchema, {
-    auth: {
-      type: "basic",
-      password: input.password,
-      username: input.username,
-    },
-    method: "PUT",
-    path: input.fingerprint
-      ? `/v2/oauth2/authorizations/clients/${encodePathSegment(input.clientId)}/${encodePathSegment(input.fingerprint)}`
-      : `/v2/oauth2/authorizations/clients/${encodePathSegment(input.clientId)}`,
-    query: {
-      callback_url: input.callbackUrl,
-      client_name: input.clientName,
-      client_secret: input.clientSecret,
-    },
-  }).pipe(selectJsonFields("access_token", "user_id"), withOperationErrors(LoginErrorSpec));
+  decodeAuthInput("login", LoginInputSchema, input, (decodedInput) =>
+    requestJson(LoginResponseSchema, {
+      auth: {
+        type: "basic",
+        password: decodedInput.password,
+        username: decodedInput.username,
+      },
+      method: "PUT",
+      path: decodedInput.fingerprint
+        ? `/v2/oauth2/authorizations/clients/${encodePathSegment(decodedInput.clientId)}/${encodePathSegment(decodedInput.fingerprint)}`
+        : `/v2/oauth2/authorizations/clients/${encodePathSegment(decodedInput.clientId)}`,
+      query: {
+        callback_url: decodedInput.callbackUrl,
+        client_name: decodedInput.clientName,
+        client_secret: decodedInput.clientSecret,
+      },
+    }).pipe(selectJsonFields("access_token", "user_id")),
+  ).pipe(withOperationErrors(LoginErrorSpec));
 export const logout = (): Effect.Effect<
   Schema.Schema.Type<typeof OkResponseSchema>,
   PutioSdkError,
@@ -441,31 +470,35 @@ export const register = (
   RegisterError,
   PutioSdkContext
 > =>
-  requestJson(ResetPasswordEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    body: {
-      type: "form",
-      value: input,
-    },
-    method: "POST",
-    path: "/v2/registration/register",
-  }).pipe(selectJsonFields("access_token"), withOperationErrors(RegisterErrorSpec));
+  decodeAuthInput("register", RegisterInputSchema, input, (decodedInput) =>
+    requestJson(ResetPasswordEnvelopeSchema, {
+      auth: {
+        type: "none",
+      },
+      body: {
+        type: "form",
+        value: decodedInput,
+      },
+      method: "POST",
+      path: "/v2/registration/register",
+    }).pipe(selectJsonFields("access_token")),
+  ).pipe(withOperationErrors(RegisterErrorSpec));
 export const exists = (
   key: "mail" | "username",
   value: string,
 ): Effect.Effect<boolean, PutioSdkError, PutioSdkContext> =>
-  requestJson(ExistsEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    method: "GET",
-    path: `/v2/registration/exists/${encodePathSegment(key)}`,
-    query: {
-      value,
-    },
-  }).pipe(selectJsonField("exists"));
+  decodeAuthInput("exists", AuthExistsInputSchema, { key, value }, (decodedInput) =>
+    requestJson(ExistsEnvelopeSchema, {
+      auth: {
+        type: "none",
+      },
+      method: "GET",
+      path: `/v2/registration/exists/${encodePathSegment(decodedInput.key)}`,
+      query: {
+        value: decodedInput.value,
+      },
+    }).pipe(selectJsonField("exists")),
+  );
 export const getVoucher = (
   code: string,
 ): Effect.Effect<
@@ -473,13 +506,15 @@ export const getVoucher = (
   VoucherLookupError,
   PutioSdkContext
 > =>
-  requestJson(VoucherEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    method: "GET",
-    path: `/v2/registration/voucher/${encodePathSegment(code)}`,
-  }).pipe(selectJsonField("voucher"), withOperationErrors(VoucherLookupErrorSpec));
+  decodeAuthInput("getVoucher", NonEmptyStringSchema, code, (decodedCode) =>
+    requestJson(VoucherEnvelopeSchema, {
+      auth: {
+        type: "none",
+      },
+      method: "GET",
+      path: `/v2/registration/voucher/${encodePathSegment(decodedCode)}`,
+    }).pipe(selectJsonField("voucher")),
+  ).pipe(withOperationErrors(VoucherLookupErrorSpec));
 export const getGiftCard = (
   code: string,
 ): Effect.Effect<
@@ -487,13 +522,15 @@ export const getGiftCard = (
   GiftCardLookupError,
   PutioSdkContext
 > =>
-  requestJson(GiftCardEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    method: "GET",
-    path: `/v2/registration/gift_card/${encodePathSegment(code)}`,
-  }).pipe(selectJsonField("gift_card"), withOperationErrors(GiftCardLookupErrorSpec));
+  decodeAuthInput("getGiftCard", NonEmptyStringSchema, code, (decodedCode) =>
+    requestJson(GiftCardEnvelopeSchema, {
+      auth: {
+        type: "none",
+      },
+      method: "GET",
+      path: `/v2/registration/gift_card/${encodePathSegment(decodedCode)}`,
+    }).pipe(selectJsonField("gift_card")),
+  ).pipe(withOperationErrors(GiftCardLookupErrorSpec));
 export const getFamilyInvite = (
   code: string,
 ): Effect.Effect<
@@ -501,13 +538,15 @@ export const getFamilyInvite = (
   FamilyInviteLookupError,
   PutioSdkContext
 > =>
-  requestJson(FamilyInviteEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    method: "GET",
-    path: `/v2/registration/family/${encodePathSegment(code)}`,
-  }).pipe(selectJsonField("invite"), withOperationErrors(FamilyInviteLookupErrorSpec));
+  decodeAuthInput("getFamilyInvite", NonEmptyStringSchema, code, (decodedCode) =>
+    requestJson(FamilyInviteEnvelopeSchema, {
+      auth: {
+        type: "none",
+      },
+      method: "GET",
+      path: `/v2/registration/family/${encodePathSegment(decodedCode)}`,
+    }).pipe(selectJsonField("invite")),
+  ).pipe(withOperationErrors(FamilyInviteLookupErrorSpec));
 export const getFriendInvite = (
   code: string,
 ): Effect.Effect<
@@ -515,13 +554,15 @@ export const getFriendInvite = (
   FriendInviteLookupError,
   PutioSdkContext
 > =>
-  requestJson(FriendInviteEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    method: "GET",
-    path: `/v2/registration/friend/${encodePathSegment(code)}`,
-  }).pipe(selectJsonField("invite"), withOperationErrors(FriendInviteLookupErrorSpec));
+  decodeAuthInput("getFriendInvite", NonEmptyStringSchema, code, (decodedCode) =>
+    requestJson(FriendInviteEnvelopeSchema, {
+      auth: {
+        type: "none",
+      },
+      method: "GET",
+      path: `/v2/registration/friend/${encodePathSegment(decodedCode)}`,
+    }).pipe(selectJsonField("invite")),
+  ).pipe(withOperationErrors(FriendInviteLookupErrorSpec));
 export const forgotPassword = (
   mail: string,
 ): Effect.Effect<
@@ -529,19 +570,21 @@ export const forgotPassword = (
   ForgotPasswordError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    auth: {
-      type: "none",
-    },
-    body: {
-      type: "form",
-      value: {
-        mail,
+  decodeAuthInput("forgotPassword", NonEmptyStringSchema, mail, (decodedMail) =>
+    requestJson(OkResponseSchema, {
+      auth: {
+        type: "none",
       },
-    },
-    method: "POST",
-    path: "/v2/registration/password/forgot",
-  }).pipe(withOperationErrors(ForgotPasswordErrorSpec));
+      body: {
+        type: "form",
+        value: {
+          mail: decodedMail,
+        },
+      },
+      method: "POST",
+      path: "/v2/registration/password/forgot",
+    }),
+  ).pipe(withOperationErrors(ForgotPasswordErrorSpec));
 export const resetPassword = (
   key: string,
   password: string,
@@ -552,62 +595,70 @@ export const resetPassword = (
   ResetPasswordError,
   PutioSdkContext
 > =>
-  requestJson(ResetPasswordEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    body: {
-      type: "form",
-      value: {
-        key,
-        password,
-      },
-    },
-    method: "POST",
-    path: "/v2/registration/password/reset",
-  }).pipe(selectJsonFields("access_token"), withOperationErrors(ResetPasswordErrorSpec));
-export const getCode = (input: {
-  readonly appId: number | string;
-  readonly clientName?: string;
-}): Effect.Effect<
+  decodeAuthInput(
+    "resetPassword",
+    AuthResetPasswordInputSchema,
+    { key, password },
+    (decodedInput) =>
+      requestJson(ResetPasswordEnvelopeSchema, {
+        auth: {
+          type: "none",
+        },
+        body: {
+          type: "form",
+          value: decodedInput,
+        },
+        method: "POST",
+        path: "/v2/registration/password/reset",
+      }).pipe(selectJsonFields("access_token")),
+  ).pipe(withOperationErrors(ResetPasswordErrorSpec));
+export const getCode = (
+  input: Schema.Schema.Type<typeof AuthGetCodeInputSchema>,
+): Effect.Effect<
   Schema.Schema.Type<typeof AuthorizationCodeSchema>,
   PutioSdkError,
   PutioSdkContext
 > =>
-  requestJson(AuthorizationCodeEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    method: "GET",
-    path: "/v2/oauth2/oob/code",
-    query: {
-      app_id: input.appId,
-      client_name: input.clientName,
-    },
-  }).pipe(selectJsonFields("code", "qr_code_url"));
+  decodeAuthInput("getCode", AuthGetCodeInputSchema, input, (decodedInput) =>
+    requestJson(AuthorizationCodeEnvelopeSchema, {
+      auth: {
+        type: "none",
+      },
+      method: "GET",
+      path: "/v2/oauth2/oob/code",
+      query: {
+        app_id: decodedInput.appId,
+        client_name: decodedInput.clientName,
+      },
+    }).pipe(selectJsonFields("code", "qr_code_url")),
+  );
 export const checkCodeMatch = (
   code: string,
 ): Effect.Effect<string | null, PutioSdkError, PutioSdkContext> =>
-  requestJson(CodeMatchEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    method: "GET",
-    path: `/v2/oauth2/oob/code/${encodePathSegment(code)}`,
-  }).pipe(selectJsonField("oauth_token"));
+  decodeAuthInput("checkCodeMatch", NonEmptyStringSchema, code, (decodedCode) =>
+    requestJson(CodeMatchEnvelopeSchema, {
+      auth: {
+        type: "none",
+      },
+      method: "GET",
+      path: `/v2/oauth2/oob/code/${encodePathSegment(decodedCode)}`,
+    }).pipe(selectJsonField("oauth_token")),
+  );
 export const linkDevice = (
   code: string,
 ): Effect.Effect<Schema.Schema.Type<typeof OAuthAppSchema>, LinkDeviceError, PutioSdkContext> =>
-  requestJson(LinkDeviceEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: {
-        code,
+  decodeAuthInput("linkDevice", NonEmptyStringSchema, code, (decodedCode) =>
+    requestJson(LinkDeviceEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: {
+          code: decodedCode,
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/oauth2/oob/code",
-  }).pipe(selectJsonField("app"), withOperationErrors(LinkDeviceErrorSpec));
+      method: "POST",
+      path: "/v2/oauth2/oob/code",
+    }).pipe(selectJsonField("app")),
+  ).pipe(withOperationErrors(LinkDeviceErrorSpec));
 export const grants = (): Effect.Effect<
   ReadonlyArray<Schema.Schema.Type<typeof OAuthAppSchema>>,
   GrantsError,
@@ -624,10 +675,12 @@ export const revokeApp = (
   RevokeOAuthGrantError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/oauth/grants/${encodePathSegment(id)}/delete`,
-  }).pipe(withOperationErrors(RevokeOAuthGrantErrorSpec));
+  decodeAuthInput("revokeApp", PositiveIntegerSchema, id, (decodedId) =>
+    requestJson(OkResponseSchema, {
+      method: "POST",
+      path: `/v2/oauth/grants/${encodePathSegment(decodedId)}/delete`,
+    }),
+  ).pipe(withOperationErrors(RevokeOAuthGrantErrorSpec));
 export const clients = (): Effect.Effect<
   ReadonlyArray<Schema.Schema.Type<typeof OAuthAppSessionSchema>>,
   ClientsError,
@@ -644,10 +697,12 @@ export const revokeClient = (
   RevokeOAuthClientError,
   PutioSdkContext
 > =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/oauth/clients/${encodePathSegment(id)}/delete`,
-  }).pipe(withOperationErrors(RevokeOAuthClientErrorSpec));
+  decodeAuthInput("revokeClient", PositiveIntegerSchema, id, (decodedId) =>
+    requestJson(OkResponseSchema, {
+      method: "POST",
+      path: `/v2/oauth/clients/${encodePathSegment(decodedId)}/delete`,
+    }),
+  ).pipe(withOperationErrors(RevokeOAuthClientErrorSpec));
 export const revokeAllClients = (): Effect.Effect<
   Schema.Schema.Type<typeof OkResponseSchema>,
   RevokeAllOAuthClientsError,
@@ -660,16 +715,18 @@ export const revokeAllClients = (): Effect.Effect<
 export const validateToken = (
   token: string,
 ): Effect.Effect<ValidateTokenResponse, PutioSdkError, PutioSdkContext> =>
-  requestJson(ValidateTokenResponseSchema, {
-    auth: {
-      type: "none",
-    },
-    method: "GET",
-    path: "/v2/oauth2/validate",
-    query: {
-      oauth_token: token,
-    },
-  });
+  decodeAuthInput("validateToken", NonEmptyStringSchema, token, (decodedToken) =>
+    requestJson(ValidateTokenResponseSchema, {
+      auth: {
+        type: "none",
+      },
+      method: "GET",
+      path: "/v2/oauth2/validate",
+      query: {
+        oauth_token: decodedToken,
+      },
+    }),
+  );
 export const generateTOTP = (): Effect.Effect<
   GenerateTOTPResponse,
   GenerateTOTPError,
@@ -690,28 +747,33 @@ export const verifyTOTP = (
   twoFactorScopedToken: string,
   code: string,
 ): Effect.Effect<VerifyTOTPResponse, VerifyTOTPError, PutioSdkContext> =>
-  requestJson(VerifyTOTPEnvelopeSchema, {
-    auth: {
-      type: "none",
-    },
-    body: {
-      type: "form",
-      value: {
-        code,
-      },
-    },
-    method: "POST",
-    path: "/v2/two_factor/verify/totp",
-    query: {
-      oauth_token: twoFactorScopedToken,
-    },
-  }).pipe(
-    Effect.map(({ token, user_id }) => ({
-      token,
-      user_id,
-    })),
-    withOperationErrors(VerifyTOTPErrorSpec),
-  );
+  decodeAuthInput(
+    "verifyTOTP",
+    AuthVerifyTotpInputSchema,
+    { code, twoFactorScopedToken },
+    (decodedInput) =>
+      requestJson(VerifyTOTPEnvelopeSchema, {
+        auth: {
+          type: "none",
+        },
+        body: {
+          type: "form",
+          value: {
+            code: decodedInput.code,
+          },
+        },
+        method: "POST",
+        path: "/v2/two_factor/verify/totp",
+        query: {
+          oauth_token: decodedInput.twoFactorScopedToken,
+        },
+      }).pipe(
+        Effect.map(({ token, user_id }) => ({
+          token,
+          user_id,
+        })),
+      ),
+  ).pipe(withOperationErrors(VerifyTOTPErrorSpec));
 export const getRecoveryCodes = (): Effect.Effect<
   TwoFactorRecoveryCodes,
   RecoveryCodesError,


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate outbound auth requests to fail fast on bad input and avoid sending credentials to the server. Adds strict schemas and a centralized decoder to standardize errors and block invalid network calls.

- **Bug Fixes**
  - Validate inputs for login, register, exists, voucher/gift card/invite lookups, forgot/reset password, code checks/linking, revoke operations, and token/TOTP flows before any request is sent.
  - Return `PutioValidationError` for invalid input without including secrets; tests ensure no transport occurs on failures and assert no secrets in error messages, stacks, or serialized output.
  - Enforce non-empty strings and positive integers for fields like client IDs, codes, usernames, and mail; reject unknown properties.

- **Refactors**
  - Introduced `decodeAuthInput` to centralize schema decoding and consistent error mapping.
  - Added per-operation schemas (`LoginInputSchema`, `RegisterInputSchema`, `AuthExistsInputSchema`, `AuthResetPasswordInputSchema`, `AuthGetCodeInputSchema`, `AuthVerifyTotpInputSchema`) and `AuthClientIdSchema` for consistent typing.
  - Named and adopted `AuthGetCodeInput` for `getCode` to clarify device code requests.
  - Replaced ad-hoc validation with schema-driven checks across the auth domain.

<sup>Written for commit 31cf14a89421435e2780f67edf9d92bca42193ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

