### PR TITLE
fix(payment): validate outbound requests

### DIFF
--- a/src/domains/payment.spec.ts
+++ b/src/domains/payment.spec.ts
@@ -1,4 +1,4 @@
-import { PutioOperationError } from "../core/errors.js";
+import { PutioOperationError, PutioValidationError } from "../core/errors.js";
 import { describe, expect, it } from "vite-plus/test";
 
 import * as payment from "./payment.js";
@@ -394,6 +394,53 @@ describe("payment domain", () => {
         { accessToken: "token-123" },
       ),
     ).toBe("https://checkout.opennode.com");
+  });
+
+  it("rejects invalid payment inputs before transport", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+    const failures = await Promise.all([
+      // @ts-expect-error JavaScript callers can provide null instead of a query object.
+      runSdkExit(payment.listPaymentHistory(null), handler),
+      runSdkExit(payment.previewPaymentChangePlan({ plan_path: "" }), handler),
+      runSdkExit(
+        payment.previewPaymentChangePlan({
+          // @ts-expect-error JavaScript callers can provide unsupported payment types.
+          payment_type: "cash",
+          plan_path: "pro/monthly",
+        }),
+        handler,
+      ),
+      runSdkExit(
+        payment.submitPaymentChangePlan({
+          plan_path: "pro/monthly",
+          // @ts-expect-error JavaScript callers can provide unknown request properties.
+          unexpected: true,
+        }),
+        handler,
+      ),
+      runSdkExit(payment.confirmFastspringOrder(""), handler),
+      runSdkExit(payment.getPaymentVoucherInfo(""), handler),
+      runSdkExit(payment.redeemPaymentVoucher(""), handler),
+      runSdkExit(payment.reportPayments([]), handler),
+      runSdkExit(payment.reportPayments([0]), handler),
+      runSdkExit(payment.createPaddleWaitingPayment({ checkout_id: "", product_id: 1 }), handler),
+      runSdkExit(
+        payment.createPaddleWaitingPayment({ checkout_id: "checkout", product_id: 0 }),
+        handler,
+      ),
+      runSdkExit(payment.getPaddleBillingInvoiceUrl(0), handler),
+      runSdkExit(payment.createPaddleBillingUpdatePaymentMethodTransaction(1.5), handler),
+      runSdkExit(payment.createOpenNodeCharge(""), handler),
+    ]);
+
+    expect(
+      failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
+    expect(requestCount).toBe(0);
   });
 
   it("maps payment operation failures", async () => {

--- a/src/domains/payment.ts
+++ b/src/domains/payment.ts
@@ -11,6 +11,7 @@ import {
   selectJsonField,
   type PutioSdkContext,
 } from "../core/http.js";
+import { NonEmptyStringSchema, PositiveIntegerSchema, decodeAndRun } from "../core/validation.js";
 export const PaymentPlanTypeSchema = Schema.Literals(["onetime", "subscription"]);
 export const PaymentOptionPlanTypeSchema = Schema.Literals(["onetime", "subscription", "trial"]);
 export const PaymentProviderNameSchema = Schema.Literals([
@@ -278,24 +279,35 @@ export type PaymentChangePlanSubmitResponse = Schema.Schema.Type<
   typeof PaymentChangePlanSubmitSchema
 >;
 export type PaymentVoucherInfo = Schema.Schema.Type<typeof PaymentVoucherInfoSchema>;
-export type PaymentHistoryQuery = {
-  readonly unreported_only?: boolean;
-};
-export type PaymentChangePlanPreviewInput = {
-  readonly coupon_code?: string;
-  readonly payment_type?: Schema.Schema.Type<typeof PaymentTypeSchema>;
-  readonly plan_path: string;
-};
-export type PaymentChangePlanSubmitInput = {
-  readonly confirmation_code?: string;
-  readonly coupon_code?: string;
-  readonly payment_type?: Schema.Schema.Type<typeof PaymentTypeSchema>;
-  readonly plan_path: string;
-};
-export type PaymentPaddleWaitingPaymentInput = {
-  readonly checkout_id: string;
-  readonly product_id: number | string;
-};
+const PaymentHistoryQuerySchema = Schema.Struct({
+  unreported_only: Schema.optional(Schema.Boolean),
+});
+const PaymentChangePlanPreviewInputSchema = Schema.Struct({
+  coupon_code: Schema.optional(NonEmptyStringSchema),
+  payment_type: Schema.optional(PaymentTypeSchema),
+  plan_path: NonEmptyStringSchema,
+});
+const PaymentChangePlanSubmitInputSchema = Schema.Struct({
+  confirmation_code: Schema.optional(NonEmptyStringSchema),
+  coupon_code: Schema.optional(NonEmptyStringSchema),
+  payment_type: Schema.optional(PaymentTypeSchema),
+  plan_path: NonEmptyStringSchema,
+});
+const PaymentPaddleWaitingPaymentInputSchema = Schema.Struct({
+  checkout_id: NonEmptyStringSchema,
+  product_id: Schema.Union([NonEmptyStringSchema, PositiveIntegerSchema]),
+});
+const PaymentIdsSchema = Schema.Array(PositiveIntegerSchema).check(Schema.isMinLength(1));
+export type PaymentHistoryQuery = Schema.Schema.Type<typeof PaymentHistoryQuerySchema>;
+export type PaymentChangePlanPreviewInput = Schema.Schema.Type<
+  typeof PaymentChangePlanPreviewInputSchema
+>;
+export type PaymentChangePlanSubmitInput = Schema.Schema.Type<
+  typeof PaymentChangePlanSubmitInputSchema
+>;
+export type PaymentPaddleWaitingPaymentInput = Schema.Schema.Type<
+  typeof PaymentPaddleWaitingPaymentInputSchema
+>;
 const RestrictedPaymentError = { errorType: "invalid_scope", statusCode: 401 as const };
 const CommonPaymentActionErrors = [
   { errorType: "PAYMENT_SUB_ACCOUNT_NOT_ALLOWED", statusCode: 403 as const },
@@ -560,13 +572,15 @@ export const listPaymentOptions = (): Effect.Effect<
     path: "/v2/payment/options",
   }).pipe(selectJsonField("options"), withOperationErrors(ListPaymentOptionsErrorSpec));
 export const listPaymentHistory = (
-  query?: PaymentHistoryQuery,
+  query: PaymentHistoryQuery = {},
 ): Effect.Effect<ReadonlyArray<PaymentHistoryItem>, ListPaymentHistoryError, PutioSdkContext> =>
-  requestJson(PaymentHistoryEnvelopeSchema, {
-    method: "GET",
-    path: "/v2/payment/history",
-    query,
-  }).pipe(selectJsonField("payments"), withOperationErrors(ListPaymentHistoryErrorSpec));
+  decodeAndRun(PaymentHistoryQuerySchema, query, (decodedQuery) =>
+    requestJson(PaymentHistoryEnvelopeSchema, {
+      method: "GET",
+      path: "/v2/payment/history",
+      query: decodedQuery,
+    }).pipe(selectJsonField("payments")),
+  ).pipe(withOperationErrors(ListPaymentHistoryErrorSpec));
 export const listPaymentInvites = (): Effect.Effect<
   ReadonlyArray<Schema.Schema.Type<typeof PaymentInviteSchema>>,
   ListPaymentInvitesError,
@@ -579,38 +593,44 @@ export const listPaymentInvites = (): Effect.Effect<
 export const previewPaymentChangePlan = (
   input: PaymentChangePlanPreviewInput,
 ): Effect.Effect<PaymentChangePlanPreview, PreviewPaymentChangePlanError, PutioSdkContext> =>
-  requestJson(PaymentChangePlanPreviewSchema, {
-    method: "GET",
-    path: `/v2/payment/change_plan/${encodeURIComponent(input.plan_path)}`,
-    query: {
-      coupon_code: input.coupon_code,
-      payment_type: input.payment_type,
-    },
-  }).pipe(withOperationErrors(PreviewPaymentChangePlanErrorSpec));
+  decodeAndRun(PaymentChangePlanPreviewInputSchema, input, (decodedInput) =>
+    requestJson(PaymentChangePlanPreviewSchema, {
+      method: "GET",
+      path: `/v2/payment/change_plan/${encodeURIComponent(decodedInput.plan_path)}`,
+      query: {
+        coupon_code: decodedInput.coupon_code,
+        payment_type: decodedInput.payment_type,
+      },
+    }),
+  ).pipe(withOperationErrors(PreviewPaymentChangePlanErrorSpec));
 export const submitPaymentChangePlan = (
   input: PaymentChangePlanSubmitInput,
 ): Effect.Effect<PaymentChangePlanSubmitResponse, SubmitPaymentChangePlanError, PutioSdkContext> =>
-  requestJson(PaymentChangePlanSubmitSchema, {
-    body: {
-      type: "form",
-      value: {
-        confirmation_code: input.confirmation_code,
-        payment_type: input.payment_type,
+  decodeAndRun(PaymentChangePlanSubmitInputSchema, input, (decodedInput) =>
+    requestJson(PaymentChangePlanSubmitSchema, {
+      body: {
+        type: "form",
+        value: {
+          confirmation_code: decodedInput.confirmation_code,
+          payment_type: decodedInput.payment_type,
+        },
       },
-    },
-    method: "POST",
-    path: `/v2/payment/change_plan/${encodeURIComponent(input.plan_path)}`,
-    query: {
-      coupon_code: input.coupon_code,
-    },
-  }).pipe(withOperationErrors(SubmitPaymentChangePlanErrorSpec));
+      method: "POST",
+      path: `/v2/payment/change_plan/${encodeURIComponent(decodedInput.plan_path)}`,
+      query: {
+        coupon_code: decodedInput.coupon_code,
+      },
+    }),
+  ).pipe(withOperationErrors(SubmitPaymentChangePlanErrorSpec));
 export const confirmFastspringOrder = (
   reference: string,
 ): Effect.Effect<boolean, ConfirmFastspringOrderError, PutioSdkContext> =>
-  requestJson(PaymentFastspringConfirmEnvelopeSchema, {
-    method: "GET",
-    path: `/v2/payment/fs-confirm/${encodeURIComponent(reference)}`,
-  }).pipe(selectJsonField("confirmed"), withOperationErrors(ConfirmFastspringOrderErrorSpec));
+  decodeAndRun(NonEmptyStringSchema, reference, (decodedReference) =>
+    requestJson(PaymentFastspringConfirmEnvelopeSchema, {
+      method: "GET",
+      path: `/v2/payment/fs-confirm/${encodeURIComponent(decodedReference)}`,
+    }).pipe(selectJsonField("confirmed")),
+  ).pipe(withOperationErrors(ConfirmFastspringOrderErrorSpec));
 export const stopPaymentSubscription = (): Effect.Effect<
   void,
   StopSubscriptionError,
@@ -623,74 +643,84 @@ export const stopPaymentSubscription = (): Effect.Effect<
 export const getPaymentVoucherInfo = (
   code: string,
 ): Effect.Effect<PaymentVoucherInfo, GetPaymentVoucherInfoError, PutioSdkContext> =>
-  requestJson(PaymentVoucherInfoSchema, {
-    method: "GET",
-    path: `/v2/payment/redeem_voucher/${encodeURIComponent(code)}`,
-  }).pipe(withOperationErrors(GetPaymentVoucherInfoErrorSpec));
+  decodeAndRun(NonEmptyStringSchema, code, (decodedCode) =>
+    requestJson(PaymentVoucherInfoSchema, {
+      method: "GET",
+      path: `/v2/payment/redeem_voucher/${encodeURIComponent(decodedCode)}`,
+    }),
+  ).pipe(withOperationErrors(GetPaymentVoucherInfoErrorSpec));
 export const redeemPaymentVoucher = (
   code: string,
 ): Effect.Effect<void, RedeemPaymentVoucherError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    method: "POST",
-    path: `/v2/payment/redeem_voucher/${encodeURIComponent(code)}`,
-  }).pipe(Effect.asVoid, withOperationErrors(RedeemPaymentVoucherErrorSpec));
+  decodeAndRun(NonEmptyStringSchema, code, (decodedCode) =>
+    requestJson(OkResponseSchema, {
+      method: "POST",
+      path: `/v2/payment/redeem_voucher/${encodeURIComponent(decodedCode)}`,
+    }),
+  ).pipe(Effect.asVoid, withOperationErrors(RedeemPaymentVoucherErrorSpec));
 export const reportPayments = (
   paymentIds: ReadonlyArray<number>,
 ): Effect.Effect<void, ReportPaymentsError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: {
-        payment_ids: joinCsv(paymentIds),
+  decodeAndRun(PaymentIdsSchema, paymentIds, (decodedPaymentIds) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value: {
+          payment_ids: joinCsv(decodedPaymentIds),
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/payment/report",
-  }).pipe(Effect.asVoid, withOperationErrors(ReportPaymentsErrorSpec));
+      method: "POST",
+      path: "/v2/payment/report",
+    }),
+  ).pipe(Effect.asVoid, withOperationErrors(ReportPaymentsErrorSpec));
 export const createPaddleWaitingPayment = (
   input: PaymentPaddleWaitingPaymentInput,
 ): Effect.Effect<void, CreatePaddleWaitingPaymentError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: input,
-    },
-    method: "POST",
-    path: "/v2/payment/paddle_waiting_payment",
-  }).pipe(Effect.asVoid, withOperationErrors(CreatePaddleWaitingPaymentErrorSpec));
+  decodeAndRun(PaymentPaddleWaitingPaymentInputSchema, input, (decodedInput) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value: decodedInput,
+      },
+      method: "POST",
+      path: "/v2/payment/paddle_waiting_payment",
+    }),
+  ).pipe(Effect.asVoid, withOperationErrors(CreatePaddleWaitingPaymentErrorSpec));
 export const getPaddleBillingInvoiceUrl = (
   paymentId: number,
 ): Effect.Effect<string, GetPaddleBillingInvoiceUrlError, PutioSdkContext> =>
-  requestJson(PaymentPaddleBillingInvoiceEnvelopeSchema, {
-    method: "GET",
-    path: `/v2/payment/methods/paddle_billing/invoice/${encodeURIComponent(paymentId)}`,
-  }).pipe(selectJsonField("url"), withOperationErrors(GetPaddleBillingInvoiceUrlErrorSpec));
+  decodeAndRun(PositiveIntegerSchema, paymentId, (decodedPaymentId) =>
+    requestJson(PaymentPaddleBillingInvoiceEnvelopeSchema, {
+      method: "GET",
+      path: `/v2/payment/methods/paddle_billing/invoice/${encodeURIComponent(decodedPaymentId)}`,
+    }).pipe(selectJsonField("url")),
+  ).pipe(withOperationErrors(GetPaddleBillingInvoiceUrlErrorSpec));
 export const createPaddleBillingUpdatePaymentMethodTransaction = (
   userSubscriptionId: number,
 ): Effect.Effect<string, CreatePaddleBillingUpdatePaymentMethodTransactionError, PutioSdkContext> =>
-  requestJson(PaymentPaddleBillingUpdatePaymentMethodEnvelopeSchema, {
-    method: "GET",
-    path: `/v2/payment/methods/paddle_billing/update_payment_method/${encodeURIComponent(
-      userSubscriptionId,
-    )}`,
-  }).pipe(
-    selectJsonField("transaction_id"),
-    withOperationErrors(CreatePaddleBillingUpdatePaymentMethodTransactionErrorSpec),
-  );
+  decodeAndRun(PositiveIntegerSchema, userSubscriptionId, (decodedUserSubscriptionId) =>
+    requestJson(PaymentPaddleBillingUpdatePaymentMethodEnvelopeSchema, {
+      method: "GET",
+      path: `/v2/payment/methods/paddle_billing/update_payment_method/${encodeURIComponent(
+        decodedUserSubscriptionId,
+      )}`,
+    }).pipe(selectJsonField("transaction_id")),
+  ).pipe(withOperationErrors(CreatePaddleBillingUpdatePaymentMethodTransactionErrorSpec));
 export const createOpenNodeCharge = (
   planPath: string,
 ): Effect.Effect<string, CreateOpenNodeChargeError, PutioSdkContext> =>
-  requestJson(PaymentOpenNodeChargeEnvelopeSchema, {
-    body: {
-      type: "form",
-      value: {
-        plan_fs_path: planPath,
+  decodeAndRun(NonEmptyStringSchema, planPath, (decodedPlanPath) =>
+    requestJson(PaymentOpenNodeChargeEnvelopeSchema, {
+      body: {
+        type: "form",
+        value: {
+          plan_fs_path: decodedPlanPath,
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/payment/methods/opennode/charge",
-  }).pipe(
-    selectJsonField("opennode"),
-    Effect.map(({ checkout_url }) => checkout_url),
-    withOperationErrors(CreateOpenNodeChargeErrorSpec),
-  );
+      method: "POST",
+      path: "/v2/payment/methods/opennode/charge",
+    }).pipe(
+      selectJsonField("opennode"),
+      Effect.map(({ checkout_url }) => checkout_url),
+    ),
+  ).pipe(withOperationErrors(CreateOpenNodeChargeErrorSpec));

--- a/test/live/domains/payment.ts
+++ b/test/live/domains/payment.ts
@@ -335,16 +335,12 @@ await run("payment stop subscription on prepaid account yields typed 404", async
   }
 });
 
-await run("payment report with empty ids yields typed 400", async () => {
+await run("payment report rejects empty ids before transport", async () => {
   try {
     await ownerClient.payment.report([]);
     throw new Error("expected empty report to fail");
   } catch (error) {
-    return assertOperationError(error, {
-      domain: "payment",
-      operation: "reportPayments",
-      statusCode: 400,
-    });
+    return assertErrorTag(error, { tag: "PutioValidationError" });
   }
 });
 
@@ -367,11 +363,11 @@ await run("payment paddle waiting invalid checkout yields typed 404", async () =
   }
 });
 
-await run("payment opennode invalid plan yields typed 400", async () => {
+await run("payment opennode unknown plan yields typed 400", async () => {
   await getOwnerPaymentInfo();
 
   try {
-    await ownerClient.payment.methods.createOpenNodeCharge("");
+    await ownerClient.payment.methods.createOpenNodeCharge("codex-invalid-plan");
     throw new Error("expected createOpenNodeCharge to fail");
   } catch (error) {
     return assertOperationError(error, {


### PR DESCRIPTION
## Summary

Validate payment-domain query, path, form, CSV, and provider inputs before transport.

Part of #108. Stacked on #156.

## Changed

- validate history queries, change-plan preview/submission payloads, references, voucher codes, payment IDs, Paddle inputs, billing IDs, and OpenNode plan paths
- reject null/excess inputs, empty strings/arrays, invalid IDs, and unsupported payment-type literals
- preserve existing request serialization and operation error aliases
- update live expectations where invalid input now fails locally; retain the OpenNode backend-error probe with a non-empty unknown plan

## Review aids

Sanitized contract examples:

```ts
payment.report([])
payment.changePlan.preview({ payment_type: "cash", plan_path: "pro/monthly" })
// PutioValidationError; transport calls: 0
```

## Risks

Previously forwarded invalid runtime payment inputs now fail locally. Valid provider flows and response classification are unchanged.

## Verification

- focused payment suite: 5 tests passed
- full deterministic suite: 22 files, 133 tests passed
- Knip source check passed
- credentialed payment live suite not run
