### PR TITLE
fix(ifttt): validate event requests

### DIFF
--- a/src/domains/ifttt.ts
+++ b/src/domains/ifttt.ts
@@ -11,6 +11,8 @@ import {
   selectJsonFields,
   type PutioSdkContext,
 } from "../core/http.js";
+import { NonEmptyStringSchema, PositiveIntegerSchema, decodeAndRun } from "../core/validation.js";
+import { JsonObjectSchema } from "./config.js";
 
 const IFTTTStatusEnvelopeSchema = Schema.Struct({
   enabled: Schema.Boolean,
@@ -34,6 +36,26 @@ export type IftttEventInput =
       readonly eventType: IftttEventType;
       readonly ingredients: Record<string, unknown>;
     };
+
+const IftttPlaybackIngredientsSchema = Schema.Struct({
+  file_id: PositiveIntegerSchema,
+  file_name: NonEmptyStringSchema,
+  file_type: NonEmptyStringSchema,
+});
+const isIftttPlaybackIngredients = Schema.is(IftttPlaybackIngredientsSchema);
+const IftttEventInputSchema = Schema.Struct({
+  clientName: Schema.optional(NonEmptyStringSchema),
+  eventType: NonEmptyStringSchema,
+  ingredients: JsonObjectSchema,
+}).check(
+  Schema.makeFilter(
+    (input) =>
+      input.eventType !== "playback_started" && input.eventType !== "playback_stopped"
+        ? true
+        : isIftttPlaybackIngredients(input.ingredients),
+    { expected: "complete playback ingredients for playback events" },
+  ),
+);
 
 export const GetIftttStatusErrorSpec = definePutioOperationErrorSpec({
   domain: "ifttt",
@@ -69,15 +91,17 @@ export const getIftttStatus = (): Effect.Effect<
 export const sendIftttEvent = (
   input: IftttEventInput,
 ): Effect.Effect<void, SendIftttEventError, PutioSdkContext> =>
-  requestJson(OkResponseSchema, {
-    body: {
-      type: "form",
-      value: {
-        client_name: input.clientName,
-        event_type: input.eventType,
-        ingredients: input.ingredients,
+  decodeAndRun(IftttEventInputSchema, input, (decodedInput) =>
+    requestJson(OkResponseSchema, {
+      body: {
+        type: "form",
+        value: {
+          client_name: decodedInput.clientName,
+          event_type: decodedInput.eventType,
+          ingredients: decodedInput.ingredients,
+        },
       },
-    },
-    method: "POST",
-    path: "/v2/ifttt-client/event",
-  }).pipe(Effect.asVoid, withOperationErrors(SendIftttEventErrorSpec));
+      method: "POST",
+      path: "/v2/ifttt-client/event",
+    }),
+  ).pipe(Effect.asVoid, withOperationErrors(SendIftttEventErrorSpec));

--- a/src/domains/ifttt.ts
+++ b/src/domains/ifttt.ts
@@ -12,7 +12,7 @@ import {
   type PutioSdkContext,
 } from "../core/http.js";
 import { NonEmptyStringSchema, PositiveIntegerSchema, decodeAndRun } from "../core/validation.js";
-import { JsonObjectSchema } from "./config.js";
+import { JsonObjectSchema, type PutioJsonObject } from "./config.js";
 
 const IFTTTStatusEnvelopeSchema = Schema.Struct({
   enabled: Schema.Boolean,
@@ -34,7 +34,7 @@ export type IftttEventInput =
   | {
       readonly clientName?: string;
       readonly eventType: IftttEventType;
-      readonly ingredients: Record<string, unknown>;
+      readonly ingredients: PutioJsonObject;
     };
 
 const IftttPlaybackIngredientsSchema = Schema.Struct({

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -987,5 +987,39 @@ describe("supporting domain boundaries", () => {
       operation: "get",
       status: 404,
     });
+
+    const iftttFailure = await runSdkExit(
+      ifttt.sendIftttEvent({
+        eventType: "playback_started",
+        ingredients: {
+          file_id: 7,
+          file_name: "SDK File",
+          file_type: "VIDEO",
+        },
+      }),
+      () =>
+        jsonResponse(
+          {
+            error_message: "Missing ingredients",
+            error_type: "MISSING_INGREDIENTS",
+            status_code: 400,
+          },
+          { status: 400 },
+        ),
+      { accessToken: "token-123" },
+    );
+
+    const iftttError = expectFailure(iftttFailure);
+    expect(iftttError).toBeInstanceOf(PutioOperationError);
+    expect(iftttError).toMatchObject({
+      _tag: "PutioOperationError",
+      domain: "ifttt",
+      operation: "sendEvent",
+      reason: {
+        errorType: "MISSING_INGREDIENTS",
+        kind: "error_type",
+      },
+      status: 400,
+    });
   });
 });

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -858,6 +858,9 @@ describe("supporting domain boundaries", () => {
         clientName: "SDK",
         eventType: "playback_started",
         ingredients: {
+          client_id: "sdk",
+          client_name: "SDK",
+          created_at: "2026-08-02T00:00:00Z",
           file_id: 7,
           file_name: "SDK File",
           file_type: "VIDEO",
@@ -868,6 +871,21 @@ describe("supporting domain boundaries", () => {
         expect(body.get("client_name")).toBe("SDK");
         expect(body.get("event_type")).toBe("playback_started");
         expect(body.get("ingredients")).toContain("file_id");
+        expect(body.get("ingredients")).toContain("created_at");
+        return jsonResponse({ status: "OK" });
+      },
+      { accessToken: "token-123" },
+    );
+
+    await runSdkEffect(
+      ifttt.sendIftttEvent({
+        eventType: "custom_event",
+        ingredients: { nested: { enabled: true } },
+      }),
+      (request) => {
+        const body = getFormBody(request);
+        expect(body.get("event_type")).toBe("custom_event");
+        expect(body.get("ingredients")).toContain('"nested"');
         return jsonResponse({ status: "OK" });
       },
       { accessToken: "token-123" },

--- a/src/domains/supporting.spec.ts
+++ b/src/domains/supporting.spec.ts
@@ -898,6 +898,54 @@ describe("supporting domain boundaries", () => {
     ]);
   });
 
+  it("rejects invalid ifttt inputs before transport", async () => {
+    let requestCount = 0;
+    const handler = () => {
+      requestCount += 1;
+      return jsonResponse({ status: "OK" });
+    };
+    const failures = await Promise.all([
+      // @ts-expect-error JavaScript callers can provide null instead of a request object.
+      runSdkExit(ifttt.sendIftttEvent(null), handler),
+      runSdkExit(ifttt.sendIftttEvent({ eventType: "", ingredients: {} }), handler),
+      runSdkExit(
+        ifttt.sendIftttEvent({
+          eventType: "playback_started",
+          ingredients: { file_id: 7, file_name: "SDK File" },
+        }),
+        handler,
+      ),
+      runSdkExit(
+        ifttt.sendIftttEvent({
+          eventType: "playback_stopped",
+          ingredients: { file_id: 0, file_name: "SDK File", file_type: "VIDEO" },
+        }),
+        handler,
+      ),
+      runSdkExit(
+        ifttt.sendIftttEvent({
+          eventType: "custom_event",
+          ingredients: { created_at: new Date() },
+        }),
+        handler,
+      ),
+      runSdkExit(
+        ifttt.sendIftttEvent({
+          eventType: "custom_event",
+          ingredients: {},
+          // @ts-expect-error JavaScript callers can provide unknown request properties.
+          unexpected: true,
+        }),
+        handler,
+      ),
+    ]);
+
+    expect(
+      failures.map(expectFailure).every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
+    expect(requestCount).toBe(0);
+  });
+
   it("maps representative operation failures in supporting domains", async () => {
     const failure = await runSdkExit(
       downloadLinks.getDownloadLinks(9),

--- a/test/live/domains/ifttt.ts
+++ b/test/live/domains/ifttt.ts
@@ -6,7 +6,7 @@ const { authClient, oauthClient } = await createClients({
 });
 
 const live = createLiveHarness("ifttt live");
-const { assert, assertOperationError, finish, run, sleep } = live;
+const { assert, assertErrorTag, assertOperationError, finish, run, sleep } = live;
 
 void assertOperationError;
 void sleep;

--- a/test/live/domains/ifttt.ts
+++ b/test/live/domains/ifttt.ts
@@ -58,7 +58,7 @@ await run("ifttt sendEvent negative behavior", async () => {
   }
 });
 
-await run("ifttt sendEvent missing ingredients yields typed 400", async () => {
+await run("ifttt sendEvent rejects missing playback ingredients before transport", async () => {
   try {
     await authClient.ifttt.sendEvent({
       eventType: "playback_started",
@@ -69,12 +69,7 @@ await run("ifttt sendEvent missing ingredients yields typed 400", async () => {
     });
     throw new Error("expected missing ingredients to fail");
   } catch (error) {
-    return assertOperationError(error, {
-      domain: "ifttt",
-      errorType: "MISSING_INGREDIENTS",
-      operation: "sendEvent",
-      statusCode: 400,
-    });
+    return assertErrorTag(error, { tag: "PutioValidationError" });
   }
 });
 


### PR DESCRIPTION
## Summary

Validate IFTTT event payloads before transport while preserving forward-compatible custom event names.

Part of #108. Stacked on #157.

## Changed

- validate event type, client name, and JSON-compatible ingredients
- require a positive `file_id` and non-empty `file_name`/`file_type` for playback events
- reject null, excess, and non-JSON inputs before transport
- update the live missing-ingredient expectation to a local `PutioValidationError`

## Review aids

```ts
ifttt.sendEvent({
  eventType: "playback_started",
  ingredients: { file_id: 7, file_name: "example.mkv" },
})
// PutioValidationError; transport calls: 0
```

## Risks

Previously forwarded malformed known playback events or non-JSON custom ingredients now fail locally. Non-empty custom event types remain supported.

## Verification

- focused supporting suite: 10 tests passed
- full deterministic suite: 22 files, 134 tests passed
- Knip passed
- credentialed IFTTT live suite not run
