### PR TITLE
fix(files): validate direct access helpers

### DIFF
--- a/src/domains/files.spec.ts
+++ b/src/domains/files.spec.ts
@@ -303,11 +303,26 @@ describe("files domain", () => {
       }),
       runConfigExit(files.getApiContentUrl(0), { accessToken: "token-123" }),
       runConfigExit(
+        // @ts-expect-error JavaScript callers can supply invalid boolean options.
+        files.getApiContentUrl(42, { useTunnel: "yes" }),
+        { accessToken: "token-123" },
+      ),
+      runConfigExit(
+        // @ts-expect-error JavaScript callers can supply null options.
+        files.getApiContentUrl(42, null),
+        { accessToken: "token-123" },
+      ),
+      runConfigExit(
         // @ts-expect-error JavaScript callers can supply excess option properties.
         files.getApiContentUrl(42, { unexpected: true }),
         { accessToken: "token-123" },
       ),
       runConfigExit(files.getApiMp4DownloadUrl(0), { accessToken: "token-123" }),
+      runConfigExit(
+        // @ts-expect-error JavaScript callers can supply invalid boolean options.
+        files.getApiMp4DownloadUrl(42, { convert: "yes" }),
+        { accessToken: "token-123" },
+      ),
       runConfigExit(files.getHlsStreamUrl(42, { maxSubtitleCount: 0 }), {
         accessToken: "token-123",
       }),
@@ -318,11 +333,9 @@ describe("files domain", () => {
         accessToken: "token-123",
       }),
     ]);
-    expect(
-      invalidDirectAccess
-        .map(expectFailure)
-        .every((error) => error instanceof PutioValidationError),
-    ).toBe(true);
+    expect(invalidDirectAccess.map(expectFailure)).toEqual(
+      invalidDirectAccess.map(() => expect.any(PutioValidationError)),
+    );
   });
 
   it("covers file reads, searches, and requested-field validation", async () => {

--- a/src/domains/files.spec.ts
+++ b/src/domains/files.spec.ts
@@ -295,6 +295,34 @@ describe("files domain", () => {
     const missingTokenExit = await runConfigExit(files.getApiDownloadUrl(42));
     const missingTokenError = expectFailure(missingTokenExit);
     expect(missingTokenError).toBeInstanceOf(PutioConfigurationError);
+
+    const invalidDirectAccess = await Promise.all([
+      runConfigExit(files.getApiDownloadUrl(0), { accessToken: "token-123" }),
+      runConfigExit(files.getApiDownloadUrl(42, { name: "" }), {
+        accessToken: "token-123",
+      }),
+      runConfigExit(files.getApiContentUrl(0), { accessToken: "token-123" }),
+      runConfigExit(
+        // @ts-expect-error JavaScript callers can supply excess option properties.
+        files.getApiContentUrl(42, { unexpected: true }),
+        { accessToken: "token-123" },
+      ),
+      runConfigExit(files.getApiMp4DownloadUrl(0), { accessToken: "token-123" }),
+      runConfigExit(files.getHlsStreamUrl(42, { maxSubtitleCount: 0 }), {
+        accessToken: "token-123",
+      }),
+      runConfigExit(files.getHlsStreamUrl(42, { subtitleLanguages: [] }), {
+        accessToken: "token-123",
+      }),
+      runConfigExit(files.getHlsStreamUrl(42, { oauthToken: "" }), {
+        accessToken: "token-123",
+      }),
+    ]);
+    expect(
+      invalidDirectAccess
+        .map(expectFailure)
+        .every((error) => error instanceof PutioValidationError),
+    ).toBe(true);
   });
 
   it("covers file reads, searches, and requested-field validation", async () => {

--- a/src/domains/files.ts
+++ b/src/domains/files.ts
@@ -1325,7 +1325,10 @@ export const getApiDownloadUrl = (
   options: FileApiDownloadUrlOptions = {},
 ): Effect.Effect<string, PutioSdkError, PutioSdkConfig> =>
   decodeAndRun(
-    Schema.Struct({ fileId: PositiveFileIdSchema, options: FileApiDownloadUrlOptionsSchema }),
+    Schema.Struct({
+      fileId: PositiveFileIdSchema,
+      options: FileApiDownloadUrlOptionsSchema,
+    }),
     { fileId, options },
     (decoded) =>
       resolveRouteContext(decoded.options.oauthToken).pipe(
@@ -1342,7 +1345,10 @@ export const getApiContentUrl = (
   options: FileDirectAccessOptions = {},
 ): Effect.Effect<string, PutioSdkError, PutioSdkConfig> =>
   decodeAndRun(
-    Schema.Struct({ fileId: PositiveFileIdSchema, options: FileDirectAccessOptionsSchema }),
+    Schema.Struct({
+      fileId: PositiveFileIdSchema,
+      options: FileDirectAccessOptionsSchema,
+    }),
     { fileId, options },
     (decoded) =>
       resolveRouteContext(decoded.options.oauthToken).pipe(
@@ -1359,7 +1365,10 @@ export const getApiMp4DownloadUrl = (
   options: FileApiMp4DownloadUrlOptions = {},
 ): Effect.Effect<string, PutioSdkError, PutioSdkConfig> =>
   decodeAndRun(
-    Schema.Struct({ fileId: PositiveFileIdSchema, options: FileApiMp4DownloadUrlOptionsSchema }),
+    Schema.Struct({
+      fileId: PositiveFileIdSchema,
+      options: FileApiMp4DownloadUrlOptionsSchema,
+    }),
     { fileId, options },
     (decoded) =>
       resolveRouteContext(decoded.options.oauthToken).pipe(
@@ -1376,7 +1385,10 @@ export const getHlsStreamUrl = (
   options: FileHlsStreamUrlOptions = {},
 ): Effect.Effect<string, PutioSdkError, PutioSdkConfig> =>
   decodeAndRun(
-    Schema.Struct({ fileId: PositiveFileIdSchema, options: FileHlsStreamUrlOptionsSchema }),
+    Schema.Struct({
+      fileId: PositiveFileIdSchema,
+      options: FileHlsStreamUrlOptionsSchema,
+    }),
     { fileId, options },
     (decoded) =>
       resolveRouteContext(decoded.options.oauthToken).pipe(

--- a/src/domains/files.ts
+++ b/src/domains/files.ts
@@ -410,6 +410,27 @@ const FileUploadInputSchema = Schema.Struct({
 const FileUploadOptionsSchema = Schema.Struct({
   oauthToken: Schema.optional(NonEmptyStringSchema),
 });
+const FileDirectAccessOptionsSchema = Schema.Struct({
+  oauthToken: Schema.optional(NonEmptyStringSchema),
+  useTunnel: Schema.optional(Schema.Boolean),
+});
+const FileApiDownloadUrlOptionsSchema = FileDirectAccessOptionsSchema.pipe(
+  Schema.fieldsAssign({ name: Schema.optional(NonEmptyStringSchema) }),
+);
+const FileApiMp4DownloadUrlOptionsSchema = FileDirectAccessOptionsSchema.pipe(
+  Schema.fieldsAssign({
+    convert: Schema.optional(Schema.Boolean),
+    name: Schema.optional(NonEmptyStringSchema),
+  }),
+);
+const FileHlsStreamUrlOptionsSchema = Schema.Struct({
+  maxSubtitleCount: Schema.optional(PositiveIntegerSchema),
+  oauthToken: Schema.optional(NonEmptyStringSchema),
+  playOriginal: Schema.optional(Schema.Boolean),
+  subtitleLanguages: Schema.optional(
+    Schema.Array(NonEmptyStringSchema).check(Schema.isMinLength(1)),
+  ),
+});
 const FilesNextFileSchema = Schema.Struct({
   id: Schema.Int,
   name: Schema.String,
@@ -1303,49 +1324,69 @@ export const getApiDownloadUrl = (
   fileId: number,
   options: FileApiDownloadUrlOptions = {},
 ): Effect.Effect<string, PutioSdkError, PutioSdkConfig> =>
-  resolveRouteContext(options.oauthToken).pipe(
-    Effect.map(({ config, oauthToken }) =>
-      buildFileApiDownloadUrl(config.baseUrl ?? "https://api.put.io", fileId, {
-        ...options,
-        oauthToken,
-      }),
-    ),
+  decodeAndRun(
+    Schema.Struct({ fileId: PositiveFileIdSchema, options: FileApiDownloadUrlOptionsSchema }),
+    { fileId, options },
+    (decoded) =>
+      resolveRouteContext(decoded.options.oauthToken).pipe(
+        Effect.map(({ config, oauthToken }) =>
+          buildFileApiDownloadUrl(config.baseUrl ?? "https://api.put.io", decoded.fileId, {
+            ...decoded.options,
+            oauthToken,
+          }),
+        ),
+      ),
   );
 export const getApiContentUrl = (
   fileId: number,
   options: FileDirectAccessOptions = {},
 ): Effect.Effect<string, PutioSdkError, PutioSdkConfig> =>
-  resolveRouteContext(options.oauthToken).pipe(
-    Effect.map(({ config, oauthToken }) =>
-      buildFileApiContentUrl(config.baseUrl ?? "https://api.put.io", fileId, {
-        ...options,
-        oauthToken,
-      }),
-    ),
+  decodeAndRun(
+    Schema.Struct({ fileId: PositiveFileIdSchema, options: FileDirectAccessOptionsSchema }),
+    { fileId, options },
+    (decoded) =>
+      resolveRouteContext(decoded.options.oauthToken).pipe(
+        Effect.map(({ config, oauthToken }) =>
+          buildFileApiContentUrl(config.baseUrl ?? "https://api.put.io", decoded.fileId, {
+            ...decoded.options,
+            oauthToken,
+          }),
+        ),
+      ),
   );
 export const getApiMp4DownloadUrl = (
   fileId: number,
   options: FileApiMp4DownloadUrlOptions = {},
 ): Effect.Effect<string, PutioSdkError, PutioSdkConfig> =>
-  resolveRouteContext(options.oauthToken).pipe(
-    Effect.map(({ config, oauthToken }) =>
-      buildFileApiMp4DownloadUrl(config.baseUrl ?? "https://api.put.io", fileId, {
-        ...options,
-        oauthToken,
-      }),
-    ),
+  decodeAndRun(
+    Schema.Struct({ fileId: PositiveFileIdSchema, options: FileApiMp4DownloadUrlOptionsSchema }),
+    { fileId, options },
+    (decoded) =>
+      resolveRouteContext(decoded.options.oauthToken).pipe(
+        Effect.map(({ config, oauthToken }) =>
+          buildFileApiMp4DownloadUrl(config.baseUrl ?? "https://api.put.io", decoded.fileId, {
+            ...decoded.options,
+            oauthToken,
+          }),
+        ),
+      ),
   );
 export const getHlsStreamUrl = (
   fileId: number,
   options: FileHlsStreamUrlOptions = {},
 ): Effect.Effect<string, PutioSdkError, PutioSdkConfig> =>
-  resolveRouteContext(options.oauthToken).pipe(
-    Effect.map(({ config, oauthToken }) =>
-      buildFileHlsStreamUrl(config.baseUrl ?? "https://api.put.io", fileId, {
-        ...options,
-        oauthToken,
-      }),
-    ),
+  decodeAndRun(
+    Schema.Struct({ fileId: PositiveFileIdSchema, options: FileHlsStreamUrlOptionsSchema }),
+    { fileId, options },
+    (decoded) =>
+      resolveRouteContext(decoded.options.oauthToken).pipe(
+        Effect.map(({ config, oauthToken }) =>
+          buildFileHlsStreamUrl(config.baseUrl ?? "https://api.put.io", decoded.fileId, {
+            ...decoded.options,
+            oauthToken,
+          }),
+        ),
+      ),
   );
 export const listFileSubtitles = (
   fileId: number,


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict schema validation to file direct-access URL helpers, rejecting invalid IDs, tokens, and option shapes before building URLs. Invalid inputs return `PutioValidationError`; missing token still returns `PutioConfigurationError`.

- **Bug Fixes**
  - Enforce positive `fileId` and non-empty `oauthToken` for `getApiDownloadUrl`, `getApiContentUrl`, `getApiMp4DownloadUrl`, and `getHlsStreamUrl`.
  - Validate option types/values: `name` (non-empty), `convert`, `useTunnel`, `playOriginal`; HLS `maxSubtitleCount` > 0 and `subtitleLanguages` is a non-empty array of non-empty strings.
  - Reject null/unknown option objects and type mismatches; added tests for invalid IDs, empty tokens/names, bad HLS options, unexpected fields, and wrong boolean types.

<sup>Written for commit 990b2ffbf914c89816576f4bd4d3f4e4abbb58f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

