### PR TITLE
ci: add manual live confidence workflow

### DIFF
--- a/.github/workflows/live-confidence.yml
+++ b/.github/workflows/live-confidence.yml
@@ -1,0 +1,84 @@
+name: Live SDK confidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: Safe live target group
+        required: true
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - files
+          - transfers
+          - all-safe
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  live:
+    if: github.ref == 'refs/heads/main'
+    name: Fresh-token live / ${{ inputs.scope }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: live-sdk-confidence
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Vite+
+        uses: ./.github/actions/setup-vp
+        with:
+          node-version-file: ".node-version"
+          cache: true
+
+      - name: Install dependencies
+        run: vp install
+
+      - name: Fetch live credentials from Infisical
+        uses: Infisical/secrets-action@8a06c1bdcd5b8635d510c52d4b57a92c1ccef785 # v1.0.9
+        with:
+          method: oidc
+          identity-id: ${{ vars.PUTIO_SDK_TYPESCRIPT_INFISICAL_IDENTITY_ID }}
+          oidc-audience: https://github.com/putdotio
+          project-slug: ${{ vars.PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_SLUG }}
+          env-slug: dev
+          domain: https://eu.infisical.com
+          secret-path: /sdk-typescript
+          include-imports: true
+
+      - name: Run fresh-token live targets
+        shell: bash
+        run: |
+          case "${{ inputs.scope }}" in
+            smoke)
+              targets=(test/live/account.test.ts test/live/tunnel.test.ts)
+              ;;
+            files)
+              targets=(test/live/files.test.ts test/live/file-direct.test.ts test/live/file-tasks.test.ts)
+              ;;
+            transfers)
+              targets=(test/live/transfers.test.ts)
+              ;;
+            all-safe)
+              targets=(
+                test/live/account.test.ts
+                test/live/tunnel.test.ts
+                test/live/files.test.ts
+                test/live/file-direct.test.ts
+                test/live/file-tasks.test.ts
+                test/live/transfers.test.ts
+              )
+              ;;
+          esac
+
+          vp run test:live:fresh -- "${targets[@]}"

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -206,6 +206,21 @@ infisical run --silent \
   -- pnpm test:live:fresh -- test/live/account.test.ts test/live/tunnel.test.ts
 ```
 
+Maintainers can also dispatch the `Live SDK confidence` GitHub workflow on
+`main`. It offers fixed `smoke`, `files`, `transfers`, and `all-safe` target
+groups, authenticates to Infisical with GitHub OIDC, and runs the same
+fresh-token lifecycle. Configure these repository variables before the first
+run:
+
+- `PUTIO_SDK_TYPESCRIPT_INFISICAL_IDENTITY_ID`
+- `PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_SLUG`
+
+The Infisical identity should trust only the `putdotio/putio-sdk-typescript`
+repository on `refs/heads/main`, use the `https://github.com/putdotio`
+audience, and have read-only access to the `dev` `/sdk-typescript` path. The
+workflow stores neither an Infisical client secret nor the fresh put.io runtime
+tokens.
+
 Run `pnpm secrets:setup` once per worktree to materialize `.env.local` from the
 Infisical `/sdk-typescript` path. The materialized file is `0600` and
 gitignored. Live commands auto-load `.env.local` first and then `.env`;


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual GitHub Actions workflow to run live SDK confidence tests on `main` using fresh tokens. Supports scopes `smoke`, `files`, `transfers`, and `all-safe`. Updates `docs/TESTING.md` with OIDC setup and required repo variables.

- **New Features**
  - Adds `Live SDK confidence` (`workflow_dispatch`) that fetches secrets via `Infisical/secrets-action` (OIDC) and runs `vp run test:live:fresh` for the selected targets.
  - Restricts execution to `refs/heads/main`; no Infisical client secret or runtime tokens are stored.

- **Migration**
  - Set repo variables: `PUTIO_SDK_TYPESCRIPT_INFISICAL_IDENTITY_ID`, `PUTIO_SDK_TYPESCRIPT_INFISICAL_PROJECT_SLUG`.
  - In `Infisical`, trust only `putdotio/putio-sdk-typescript` on `refs/heads/main`, audience `https://github.com/putdotio`, with read-only access to `dev` `/sdk-typescript`.

<sup>Written for commit 27c2e145d0d69eab845fa388d8d089e592bcc54f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

