### PR TITLE
test(contracts): add public transport fixtures

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -52,6 +52,11 @@ vp run test:compat
 `lint:package` packs the package and runs `publint` plus Are The Types Wrong against the published ESM entrypoints.
 `vp run verify` blocks on both Knip graphs and executes the covered unit suite once. CI follows it with `lint:package`; Knip governs source reachability and dependency usage, while package checks and explicit API/type tests govern intentional public exports.
 
+The deterministic suite also replays sanitized public contract fixtures from
+`test/fixtures/public-contracts.ts`. They pin representative unauthenticated and
+authenticated form requests, query serialization, JSON response decoding, and
+binary response handling without credentials or private backend evidence.
+
 ## Runtime Compatibility Checks
 
 Compatibility checks are package-consumer smoke tests, not live API tests. They pack the SDK, install the tarball into throwaway external projects, and verify the public ESM entrypoints from outside the repo.

--- a/src/public-contract-fixtures.spec.ts
+++ b/src/public-contract-fixtures.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import * as auth from "./domains/auth.js";
+import * as files from "./domains/files.js";
+import * as podcast from "./domains/podcast.js";
+import * as transfers from "./domains/transfers.js";
+import { publicContractFixtures } from "../test/fixtures/public-contracts.js";
+import {
+  arrayBufferResponse,
+  getAuthorizationHeader,
+  getFormBody,
+  jsonResponse,
+  runSdkEffect,
+} from "../test/support/sdk-test.js";
+
+const accessToken = "fixture-access-token-not-a-credential";
+
+const formEntries = (body: URLSearchParams): Readonly<Record<string, string>> =>
+  Object.fromEntries(body.entries());
+
+describe("public contract fixtures", () => {
+  it("replays the unauthenticated OAuth exchange fixture", async () => {
+    const fixture = publicContractFixtures.authExchange;
+    await expect(
+      runSdkEffect(
+        auth.exchangeOAuthAuthorizationCode(fixture.input),
+        (request) => {
+          expect({ method: request.method, url: request.url }).toEqual({
+            method: fixture.request.method,
+            url: fixture.request.url,
+          });
+          expect(getAuthorizationHeader(request)).toBeUndefined();
+          expect(formEntries(getFormBody(request))).toEqual(fixture.request.form);
+          return jsonResponse(fixture.response);
+        },
+        { accessToken },
+      ),
+    ).resolves.toBe(fixture.result);
+  });
+
+  it("replays an authenticated form request and nested file response", async () => {
+    const fixture = publicContractFixtures.fileCopy;
+    await expect(
+      runSdkEffect(
+        files.copyFile(fixture.input),
+        (request) => {
+          expect({ method: request.method, url: request.url }).toEqual({
+            method: fixture.request.method,
+            url: fixture.request.url,
+          });
+          expect(getAuthorizationHeader(request)).toBe(`Token ${accessToken}`);
+          expect(formEntries(getFormBody(request))).toEqual(fixture.request.form);
+          return jsonResponse(fixture.response);
+        },
+        { accessToken },
+      ),
+    ).resolves.toEqual(fixture.response.file);
+  });
+
+  it("replays a query request and selected podcast response", async () => {
+    const fixture = publicContractFixtures.podcastLinks;
+    await expect(
+      runSdkEffect(
+        podcast.getPodcastLinks(fixture.input),
+        (request) => {
+          expect({ method: request.method, url: request.url }).toEqual(fixture.request);
+          expect(getAuthorizationHeader(request)).toBe(`Token ${accessToken}`);
+          return jsonResponse(fixture.response);
+        },
+        { accessToken },
+      ),
+    ).resolves.toEqual(fixture.result);
+  });
+
+  it("replays a binary torrent response", async () => {
+    const fixture = publicContractFixtures.transferTorrent;
+    const result = await runSdkEffect(
+      transfers.getTransferTorrent(fixture.input),
+      (request) => {
+        expect({ method: request.method, url: request.url }).toEqual(fixture.request);
+        expect(getAuthorizationHeader(request)).toBe(`Token ${accessToken}`);
+        return arrayBufferResponse(fixture.responseBytes);
+      },
+      { accessToken },
+    );
+
+    expect(Array.from(result)).toEqual(fixture.responseBytes);
+  });
+});

--- a/test/fixtures/public-contracts.ts
+++ b/test/fixtures/public-contracts.ts
@@ -1,0 +1,84 @@
+export const publicContractFixtures = {
+  authExchange: {
+    input: {
+      clientId: 321,
+      clientSecret: "fixture-client-secret-not-a-credential",
+      code: "fixture-authorization-code",
+      redirectUri: "fixture-app://oauth/callback",
+    },
+    request: {
+      form: {
+        client_id: "321",
+        client_secret: "fixture-client-secret-not-a-credential",
+        code: "fixture-authorization-code",
+        grant_type: "authorization_code",
+        redirect_uri: "fixture-app://oauth/callback",
+      },
+      method: "POST",
+      url: "https://api.put.io/v2/oauth2/access_token",
+    },
+    response: { access_token: "fixture-exchanged-token" },
+    result: "fixture-exchanged-token",
+  },
+  fileCopy: {
+    input: { fileId: 9, name: "Fixture Copy", parentId: 7 },
+    request: {
+      form: { file_id: "9", name: "Fixture Copy", parent_id: "7" },
+      method: "POST",
+      url: "https://api.put.io/v2/files/copy",
+    },
+    response: {
+      file: {
+        content_type: "video/mp4",
+        created_at: "2026-08-01T00:00:00Z",
+        crc32: null,
+        extension: ".mp4",
+        file_type: "VIDEO",
+        first_accessed_at: null,
+        folder_type: "REGULAR",
+        icon: null,
+        id: 10,
+        is_hidden: false,
+        is_mp4_available: true,
+        is_shared: false,
+        name: "Fixture Copy",
+        opensubtitles_hash: null,
+        parent_id: 7,
+        screenshot: null,
+        size: 1024,
+        updated_at: "2026-08-01T00:00:00Z",
+      },
+      status: "OK",
+    },
+  },
+  podcastLinks: {
+    input: { parentId: 42, types: ["all", "mp4"] as const },
+    request: {
+      method: "GET",
+      url: "https://api.put.io/v2/podcast/links?parent_id=42&type=all%2Cmp4",
+    },
+    response: {
+      links: {
+        all: "https://api.put.io/v2/podcast/feed/all",
+        mp4: "https://api.put.io/v2/podcast/feed/mp4",
+      },
+      status: "OK",
+      token: "fixture-podcast-token",
+    },
+    result: {
+      links: {
+        all: "https://api.put.io/v2/podcast/feed/all",
+        mp4: "https://api.put.io/v2/podcast/feed/mp4",
+      },
+      token: "fixture-podcast-token",
+    },
+  },
+  transferTorrent: {
+    input: 11,
+    request: {
+      method: "GET",
+      url: "https://api.put.io/v2/transfers/11/torrent",
+    },
+    responseBytes: [100, 56, 58],
+  },
+} as const;


### PR DESCRIPTION
## Summary

Add reusable, sanitized transport/response fixtures to deterministic verification for issue #108.

## Changed

- replay unauthenticated OAuth and authenticated file-copy form requests
- pin podcast query serialization and JSON response selection
- pin binary torrent response handling
- document the public-safe fixture boundary

## Review aids

Sanitized example:

```text
POST /v2/files/copy
file_id=9&name=Fixture+Copy&parent_id=7
-> nested file response decoded to the public File contract
```

## Risks

Test-only. Fixture values are deliberately synthetic and contain no private route evidence or credentials.

## Verification

- vp run verify
- vp run lint:package
- vp run test:compat
- Codex autoreview: clean, confidence 0.96

## Complexity

Four fixture cases and one focused replay spec; no production code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sanitized, reusable fixtures for public SDK contracts and deterministic tests to replay request/response shapes. No production code changes.

- **New Features**
  - Added `test/fixtures/public-contracts.ts` with fixtures for OAuth exchange, file copy form, podcast links query, and binary torrent response.
  - Added `src/public-contract-fixtures.spec.ts` to assert method/url, auth header, form/query serialization, and JSON/binary decoding.
  - Updated `docs/TESTING.md` to document the public-safe fixture boundary and how fixtures are replayed in the deterministic suite.

<sup>Written for commit c5f5b18163a05650545a4d2c0ba27a3e9c622185. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

