### PR TITLE
ci(release): resolve releaser bot user id at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,19 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+      - name: Resolve release bot identity
+        id: release-bot-identity
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
+            echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot]" >&2
+            exit 1
+          fi
+          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -164,6 +177,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_AUTHOR_EMAIL: 283001373+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_COMMITTER_EMAIL: 283001373+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com


### PR DESCRIPTION
## Summary
- Resolve the release bot numeric user id at runtime via `/users/{app-slug}[bot]`
- Use that id in noreply commit emails instead of a hardcoded value

## Test plan
- [ ] CI green on this PR
- [ ] Next release commit email links to `putio-releaser[bot]`

## Review aids
Before: `283001373+${{ steps.release-bot.outputs.app-slug }}[bot]@…`
After: `${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@…`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the release bot user ID at runtime and use it in commit noreply emails instead of a hardcoded number. This keeps author links working for `putio-releaser[bot]` if the GitHub App is recreated.

- **Bug Fixes**
  - Fetch the numeric bot ID via `gh api /users/{APP_SLUG}[bot]` and expose it as `user-id`.
  - Use that ID in `GIT_AUTHOR_EMAIL` and `GIT_COMMITTER_EMAIL`, replacing `283001373`.

<sup>Written for commit aaab981a28647fd17216aaa3a60bfd99937d3646. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

