### PR TITLE
chore: fold lint:package into verify, add PR/issue templates, compat aggregate job

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Report a reproducible problem in @putdotio/sdk
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include a minimal code sample, the SDK call, or a failing test if useful.
+      placeholder: |
+        1. Create a client with ...
+        2. Call ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: SDK version, runtime and version (Node, Bun, browser), and any relevant bundler or framework notes.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste any relevant error output, typed failure values, or stack traces.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched for existing issues covering the same problem
+          required: true
+        - label: I removed secrets, tokens, and private account data from the report
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an improvement to @putdotio/sdk
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What API surface, capability, or workflow is not served well today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior you want and any constraints or examples.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Describe any workarounds or other approaches you considered.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched for existing issues or discussions covering the same idea
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- What changed
+- Why it changed
+
+## Verification
+
+- [ ] `vp run verify`
+- Additional targeted checks (`vp run test:live`, `vp run test:compat`, single-target live commands):
+  -
+
+## Notes
+
+- Risks, rollout notes, or follow-up work
+- If not applicable, write `N/A`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Verify repository
         run: vp run verify
 
-      - name: Verify package metadata
-        run: vp run lint:package
-
   compatibility:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     name: Compatibility / ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,26 @@ jobs:
         env:
           PUTIO_COMPAT_BROWSERS: ${{ matrix.browser }}
 
+  compatibility-result:
+    if: always() && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]'))
+    name: Compatibility result
+    needs:
+      - compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+
+    steps:
+      - name: Check compatibility matrix result
+        env:
+          COMPATIBILITY_RESULT: ${{ needs.compatibility.result }}
+        run: |
+          set -euo pipefail
+          echo "compatibility matrix result: ${COMPATIBILITY_RESULT}"
+          if [[ "${COMPATIBILITY_RESULT}" == "failure" || "${COMPATIBILITY_RESULT}" == "cancelled" ]]; then
+            exit 1
+          fi
+
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]')
     name: Release SDK

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@
 - [Architecture](./docs/ARCHITECTURE.md)
 - [Testing](./docs/TESTING.md)
 - [Distribution](./docs/DISTRIBUTION.md)
+- [API Coverage](./docs/API-COVERAGE.md) — endpoint completeness contract and the route matrix
+- [Migrating to v11](./docs/MIGRATING_V11.md) — removed public contracts and their replacements
 
 ## Commands
 
@@ -23,6 +25,11 @@
 - `vp run test:live`
 - `vp run verify`
 - `vp run bootstrap:tokens`
+
+## Teardown
+
+- `vp run clean` — remove generated artifacts (`.live-build`, `.turbo`, `coverage`, `dist`)
+- `pnpm secrets:clean` — remove the ignored live-test `.env.local` files
 
 ## Worktrees
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,11 @@ Run the full repo guardrail before opening or updating a pull request:
 vp run verify
 ```
 
-That command runs formatting, linting, package build, unit tests, and coverage using the same repo-local entrypoint CI relies on.
+That command runs formatting, linting, package build, package-surface checks, unit tests, and coverage using the same repo-local entrypoint CI relies on.
 
 The coverage guardrail is unit-only and counts all production files under `src/**`.
 Live tests are separate confidence checks outside the coverage threshold.
-Package-surface verification runs in CI through `vp run lint:package`.
+Package-surface verification runs inside `vp run verify` through `lint:package`.
 
 ## Live Verification
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -9,10 +9,9 @@ GitHub Actions owns releases for this repo and the workflow runs on GitHub-hoste
 The pipeline runs these release steps on `main`:
 
 1. `vp install`
-2. `vp run verify`
-3. `vp run lint:package`
-4. compatibility matrix for Node, Chromium, Firefox, WebKit, and Bun
-5. run `semantic-release` through the release action
+2. `vp run verify` (includes `lint:package`)
+3. compatibility matrix for Node, Chromium, Firefox, WebKit, and Bun, plus the aggregate `Compatibility result` job
+4. run `semantic-release` through the release action
 
 The workflow uses `.releaserc.json` as the release source of truth. The release action is SHA-pinned and every `extra_plugins` entry is version-pinned, so the secret-bearing release job does not fetch unversioned semantic-release plugins.
 
@@ -55,7 +54,6 @@ Before changing distribution wiring, validate the repo-local guardrails the work
 ```bash
 vp install
 vp run verify
-vp run lint:package
 vp run test:compat
 ```
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -50,7 +50,7 @@ vp run test:compat
 `lint:unused` runs Knip against source, tests, live tests, scripts, and config files to detect unused files, dependencies, and exports.
 `lint:unused:prod` packs the package, then runs Knip's production-only graph with ignored build output visible. Knip's explicit entry and project patterns keep that analysis limited to the package, tests, scripts, and root config rather than unrelated ignored files.
 `lint:package` packs the package and runs `publint` plus Are The Types Wrong against the published ESM entrypoints.
-`vp run verify` blocks on both Knip graphs and executes the covered unit suite once. CI follows it with `lint:package`; Knip governs source reachability and dependency usage, while package checks and explicit API/type tests govern intentional public exports.
+`vp run verify` blocks on both Knip graphs, runs `lint:package`, and executes the covered unit suite once; CI runs the same command. Knip governs source reachability and dependency usage, while package checks and explicit API/type tests govern intentional public exports.
 
 The deterministic suite also replays sanitized public contract fixtures from
 `test/fixtures/public-contracts.ts`. They pin representative unauthenticated and

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "test:live:fresh": "vp pack && node ./scripts/test-live-fresh.ts",
     "validate:routes": "vp pack && vp run validate:routes:packed",
     "validate:routes:packed": "node ./scripts/validate-route-matrix.ts",
-    "verify": "vp check . && vp pack && knip && knip --production --no-gitignore && vp run validate:routes:packed && vp run lint:package && vp test run --coverage --passWithNoTests"
+    "verify": "vp check . && vp run lint:package && knip && knip --production --no-gitignore && vp run validate:routes:packed && vp test run --coverage --passWithNoTests"
   },
   "dependencies": {
     "effect": "4.0.0-beta.107"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "test:live:fresh": "vp pack && node ./scripts/test-live-fresh.ts",
     "validate:routes": "vp pack && vp run validate:routes:packed",
     "validate:routes:packed": "node ./scripts/validate-route-matrix.ts",
-    "verify": "vp check . && vp pack && knip && knip --production --no-gitignore && vp run validate:routes:packed && vp test run --coverage --passWithNoTests"
+    "verify": "vp check . && vp pack && knip && knip --production --no-gitignore && vp run validate:routes:packed && vp run lint:package && vp test run --coverage --passWithNoTests"
   },
   "dependencies": {
     "effect": "4.0.0-beta.107"


### PR DESCRIPTION
## Summary

- Fold `lint:package` into the `verify` script and drop the duplicate CI step — local `vp run verify` now matches CI.
- Add `.github/pull_request_template.md` (Summary/Verification/Notes) and YAML issue forms (bug + feature) with `blank_issues_enabled: false`.
- Add a `Compatibility result` aggregate job: needs all 5 compatibility matrix jobs, runs on `if: always()`, fails on matrix `failure` or `cancelled`. Coordinator should add it as a required status check; this PR does not touch rulesets.
- AGENTS.md: new Teardown section (`clean`, `secrets:clean`) and Start Here routes for `docs/API-COVERAGE.md` and `docs/MIGRATING_V11.md`.

Fixes #176

## Verification

- [x] `vp run verify` — 9 tasks green including `lint:package` (publint + attw), 24 test files, 143 tests, 98% statement coverage
- Additional targeted checks (`vp run test:live`, `vp run test:compat`, single-target live commands):
  - N/A — no runtime code changed; the compatibility matrix runs on this PR and exercises the new aggregate job

## Notes

- `Compatibility result` treats a skipped matrix (upstream `Verify SDK` failure) as pass; `Verify SDK` remains the gate for that path.