### PR TITLE
ci: run-level concurrency and bounded browser install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Install browser runtime
         if: startsWith(matrix.target, 'browser-')
+        timeout-minutes: 10
         run: vp exec playwright install --with-deps ${{ matrix.browser }}
 
       - name: Verify compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,16 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     name: Verify SDK
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    concurrency:
-      group: verify-${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     permissions:
       contents: read
 
@@ -46,9 +47,6 @@ jobs:
       - verify
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    concurrency:
-      group: compatibility-${{ matrix.target }}-${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
## Summary

- Replaces the job-level `concurrency` blocks on `verify` and the compatibility matrix with a single workflow-level group; superseded pull request runs now cancel atomically instead of job by job. Pushes to `main` queue (`cancel-in-progress` only for `pull_request`), so release runs are never cancelled.
- Caps the `Install browser runtime` step at `timeout-minutes: 10`.

### What actually happened on #177

Diagnosed from the run history, not the hypothesis in the issue:

- The webkit job that needed `gh run rerun --failed` (run [32295425657](https://github.com/putdotio/putio-sdk-typescript/actions/runs/32295425657) attempt 1) was **not** cancelled by a concurrency group. Its `Install browser runtime` step (`playwright install --with-deps webkit`) hung on `apt-get update` fetching `archive.ubuntu.com` at 19:54:40Z and sat silent until the job's `timeout-minutes: 30` killed it — annotation: "The job has exceeded the maximum execution time of 30m0s". A timeout kill reports conclusion `cancelled`, which made it look like a concurrency cancel; the aggregate then correctly failed.
- The job-level concurrency design is still a real defect, just a different one: the superseded run ([32294909565](https://github.com/putdotio/putio-sdk-typescript/actions/runs/32294909565)) had each browser job cancelled individually ("Canceling since a higher priority waiting request for `compatibility-browser-webkit-CI-refs/pull/177/merge` exists"), leaving a red `failure` aggregate on the old run instead of a cancelled run. And because matrix jobs only enter their groups after `verify` finishes, start order can invert across runs: an older run whose `verify` finishes later can cancel a newer run's in-progress matrix job. Run-level grouping removes both, and GitHub orders run-level cancellation by run creation.

### Race proof

Two rapid pushes to this branch, second push landing while the first run's full matrix was in progress:

- 02:16:33Z push `f3034b0` -> run [32324091171](https://github.com/putdotio/putio-sdk-typescript/actions/runs/32324091171); all 5 matrix jobs in progress by 02:17:57Z.
- 02:18:08Z push `c28b5c2` -> run [32324150731](https://github.com/putdotio/putio-sdk-typescript/actions/runs/32324150731).
- Run 1: conclusion `cancelled` atomically; every cancelled job carries the single run-level annotation "Canceling since a higher priority waiting request for CI-refs/pull/179/merge exists" -- no per-target group cancellations. (Its `if: always()` aggregate still reports failure on the superseded SHA; only the latest SHA gates the PR.)
- Run 2: attempt 1, fully green -- `Verify SDK`, all 5 matrix targets, and `Compatibility result` succeeded with zero intra-run cancellation and no rerun.

## Verification

- [x] `vp run verify`
- Additional targeted checks (`vp run test:live`, `vp run test:compat`, single-target live commands):
  - `actionlint .github/workflows/ci.yml` clean
  - rapid-push supersede proof (see above)

## Notes

- The apt mirror stall that caused the #177 rerun is transient infrastructure; the 10-minute step cap bounds it but a stall still needs one rerun. A browser-binary cache or bounded retry is possible follow-up if it recurs.

Fixes #178
